### PR TITLE
Fix potential integer overflow bug in calc_top_features_internal()

### DIFF
--- a/src/calc_top_features.cpp
+++ b/src/calc_top_features.cpp
@@ -50,8 +50,8 @@ Rcpp::RObject calc_top_features_internal(M mat, Rcpp::RObject topvec, Rcpp::RObj
         } else {
             survivors=input;
         }
-        double total=std::accumulate(survivors.begin(), survivors.end(), 0);
-            
+        double total=std::accumulate(survivors.begin(), survivors.end(), 0.0);
+
         // Sorting in descending order, and computing the accumulated total.
         std::partial_sort(survivors.begin(), survivors.begin() + top[ntop-1], survivors.end(), std::greater<T>());
         size_t x=0;


### PR DESCRIPTION
Hey Davis,

This is probably one for @LTLA to check since I think he wrote this code. 

`std::accumulate()` takes its return type from `init`. Previously, this line would return an int that was then cast to a double. Now, the result is explicitly a double. This avoids potential integer overflow in the sum.

I only learnt this (https://stackoverflow.com/questions/3604478/c-stdaccumulate-doesnt-give-the-expected-sum) because I'm using **scater** to teach myself **beachmat**. I'd implemented a colSums-like function using `std::accumulate()` and was getting integer overflow until I switched `init` from `0` (int) to `0.0` (double). 