### PR TITLE
Force recompilation after Rcpp updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,17 +9,18 @@ Authors@R: c(person("Davis", "McCarthy", role=c("aut", "cre"),
         person("Vladimir", "Kiselev", role=c("ctb"),
         email="vk6@sanger.ac.uk"))
 Maintainer: Davis McCarthy <davis@ebi.ac.uk>
-Version: 1.7.1
-Date: 2017-11-04
+Version: 1.7.2
+Date: 2017-11-25
 License: GPL (>= 2)
 Title: Single-cell analysis toolkit for gene expression data in R
 Description: A collection of tools for doing various analyses of
         single-cell RNA-seq gene expression data, with a focus on
         quality control.
-Depends: R (>= 3.4), Biobase, ggplot2, SingleCellExperiment, SummarizedExperiment
+Depends: R (>= 3.5), Biobase, ggplot2, SingleCellExperiment, SummarizedExperiment
 Imports: biomaRt, BiocGenerics, data.table, dplyr, edgeR, ggbeeswarm, grid, limma,
         Matrix, matrixStats, methods, parallel, plyr, reshape2, rhdf5, rjson, 
-        S4Vectors, shiny, shinydashboard, stats, tximport, utils, viridis, Rcpp
+        S4Vectors, shiny, shinydashboard, stats, tximport, utils, viridis, 
+        Rcpp (>= 0.12.14)
 Suggests: BiocStyle, beachmat, cowplot, cluster, destiny, knitr, monocle,
         mvoutlier, rmarkdown, Rtsne, testthat, magrittr
 VignetteBuilder: knitr


### PR DESCRIPTION
User's machines will not recompile _beachmat_, _scater_ and _scran_ upon updates to _Rcpp_. This means that, potentially, an attempt to re-install _scater_ will result in a shared library using new _Rcpp_ code, that doesn't work with the existing _beachmat_ library using old _Rcpp_ code. We must force all code to recompile by bumping the version numbers in _beachmat_ and dependent packages. 

While I've changed the `master` here, the same updates need to be applied to `RELEASE_3_6` and **committed to Bioconductor's Git server**. Otherwise the shit will hit the fan on user-side machines.