### PR TITLE
Switch to beachmat v2 and other changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ biocViews: ImmunoOncology, SingleCell, RNASeq, QualityControl, Preprocessing, No
         Visualization, DimensionReduction, Transcriptomics,
         GeneExpression, Sequencing, Software, DataImport,
         DataRepresentation, Infrastructure, Coverage
-LinkingTo: Rhdf5lib, Rcpp, beachmat
+LinkingTo: Rcpp, beachmat
 SystemRequirements: C++11
 RoxygenNote: 6.1.1
 NeedsCompilation: yes

--- a/R/calculateAverage.R
+++ b/R/calculateAverage.R
@@ -61,32 +61,29 @@ calculateAverage <- function(object, exprs_values="counts", use_size_factors = T
     object <- centreSizeFactors(object)
     sf_list <- .get_all_sf_sets(object)
 
-    # Parallelize across *cells* - for RNA-seq applications, genes are fixed but number of cells can increase.
-    assign_work <- .assign_jobs_to_workers(ncol(object), BPPARAM)
+    # Parallelize across *genes* to ensure numerically IDENTICAL results.
+    subset_row <- .subset2index(subset_row, object, byrow=TRUE)
+    by_core <- .split_vector_by_workers(subset_row-1L, BPPARAM)
 
     # Computes the average count, adjusting for size factors or library size.
-    subset_row <- .subset2index(subset_row, object, byrow=TRUE)
-    bp.out <- bpmapply(FUN=.compute_averages, start=assign_work$start, end=assign_work$end,
+    bp.out <- bpmapply(FUN=.compute_averages, subset=by_core,
         MoreArgs=list(
             mat=assay(object, exprs_values, withDimnames=FALSE), 
             sf_values=sf_list$size.factors, 
-            sf_index=sf_list$index - 1L, 
-            subset=subset_row-1L
+            sf_index=sf_list$index - 1L
         ),
         BPPARAM=BPPARAM, SIMPLIFY=FALSE, USE.NAMES=FALSE)
 
-    ave <- Reduce("+", bp.out)
-    ave <- ave/ncol(object)
-
+    ave <- unlist(bp.out)/ncol(object)
     names(ave) <- rownames(object)[subset_row]
     ave
 }
 
-.compute_averages <- function(mat, sf_values, sf_index, subset, start, end) 
+.compute_averages <- function(mat, sf_values, sf_index, subset)
 # A helper function defined in the scater namespace.
 # This avoids the need to reattach scater in bplapply for SnowParam().
 {
-    .Call(cxx_ave_exprs, mat, sf_values, sf_index, subset, start, end)
+    .Call(cxx_ave_exprs, mat, sf_values, sf_index, subset)
 }
 
 #' @rdname calculateAverage

--- a/R/calculateQCMetrics.R
+++ b/R/calculateQCMetrics.R
@@ -22,6 +22,11 @@
 #' Underscores in \code{assayNames(object)} and in \code{feature_controls} or \code{cell_controls} can cause theoretically cause ambiguities in the names of the output metrics.
 #' While problems are highly unlikely, users are advised to avoid underscores when naming their controls/assays.
 #'
+#' If the expression values are double-precision, the per-row means may not be \emph{exactly} identity for different choices of \code{BPPARAM}.
+#' This is due to differences in rounding error when summation is performed across different numbers of cores.
+#' If it is important to obtain numerically identical results (e.g., when using the per-row means for sensitive procedures like t-SNE) across various parallelization schemes,
+#' we suggest manually calculating those statistics using \code{\link{rowMeans}}.
+#'
 #' @section Cell-level QC metrics:
 #' Denote the value of \code{exprs_values} as \code{X}. 
 #' Cell-level metrics are:

--- a/R/sumCountsAcrossCells.R
+++ b/R/sumCountsAcrossCells.R
@@ -57,7 +57,7 @@ sumCountsAcrossCells <- function(object, ids, exprs_values="counts", BPPARAM=Ser
 .sum_across_cols_internal <- function(mat, by_set, start, end) 
 # Internal function to drag along the namespace.
 {
-    .Call(cxx_sum_counts, mat, by_set, start, end, FALSE)
+    .Call(cxx_sum_col_counts, mat, by_set, start, end)
 }
 
 

--- a/R/sumCountsAcrossFeatures.R
+++ b/R/sumCountsAcrossFeatures.R
@@ -61,7 +61,7 @@ sumCountsAcrossFeatures <- function(object, ids, exprs_values="counts", BPPARAM=
 .sum_across_rows_internal <- function(mat, by_set, start, end) 
 # Internal function to drag along the namespace.
 {
-    .Call(cxx_sum_counts, mat, by_set, start, end, TRUE)
+    .Call(cxx_sum_row_counts, mat, by_set, start, end)
 }
 
 

--- a/man/calculateQCMetrics.Rd
+++ b/man/calculateQCMetrics.Rd
@@ -43,6 +43,11 @@ This function calculates useful quality control metrics to help with pre-process
 
 Underscores in \code{assayNames(object)} and in \code{feature_controls} or \code{cell_controls} can cause theoretically cause ambiguities in the names of the output metrics.
 While problems are highly unlikely, users are advised to avoid underscores when naming their controls/assays.
+
+If the expression values are double-precision, the per-row means may not be \emph{exactly} identity for different choices of \code{BPPARAM}.
+This is due to differences in rounding error when summation is performed across different numbers of cores.
+If it is important to obtain numerically identical results (e.g., when using the per-row means for sensitive procedures like t-SNE) across various parallelization schemes,
+we suggest manually calculating those statistics using \code{\link{rowMeans}}.
 }
 \section{Cell-level QC metrics}{
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,0 @@
-BEACHMAT_LIBS=`echo 'beachmat::pkgconfig("PKG_LIBS")'|\
-    "${R_HOME}/bin/R" --vanilla --slave`
-PKG_LIBS=$(BEACHMAT_LIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,0 @@
-BEACHMAT_LIBS=$(shell echo 'beachmat::pkgconfig("PKG_LIBS")'|\
-    "${R_HOME}/bin/R" --vanilla --slave)
-PKG_LIBS=$(BEACHMAT_LIBS)

--- a/src/combined_qc.cpp
+++ b/src/combined_qc.cpp
@@ -201,17 +201,17 @@ SEXP combined_qc_internal(M mat, Rcpp::IntegerVector start, Rcpp::IntegerVector 
     // Running through the requested stretch of cells.
     V holder(ngenes);
     for (size_t c=0; c<n_usedcells; ++c) {
-        auto cIt=mat->get_const_col(c + firstcell, holder.begin());
+        mat->get_col(c + firstcell, holder.begin());
 
-        all_PCS.fill(cIt);
+        all_PCS.fill(holder.begin());
         for (size_t fx=0; fx<nfcontrols; ++fx) {
-            control_PCS[fx].fill_subset(cIt);
+            control_PCS[fx].fill_subset(holder.begin());
         }
 
-        all_PGS.compute_summaries(cIt);
+        all_PGS.compute_summaries(holder.begin());
         auto& chosen_cc=chosen_ccs[c];
         for (auto& cx : chosen_cc) {
-            control_PGS[cx].compute_summaries(cIt);
+            control_PGS[cx].compute_summaries(holder.begin());
         }
     }
 

--- a/src/combined_qc.cpp
+++ b/src/combined_qc.cpp
@@ -2,6 +2,7 @@
 
 #include "beachmat/integer_matrix.h"
 #include "beachmat/numeric_matrix.h"
+#include "beachmat/utils/const_column.h"
 #include "utils.h"
 
 #include <stdexcept>
@@ -152,15 +153,16 @@ Rcpp::List create_output_per_gene(const per_gene_statistics<T, V>& PGS) {
 
 /* Main loop for combined_qc. */
 
-template <typename T, class V, class M>
-SEXP combined_qc_internal(M mat, Rcpp::IntegerVector start, Rcpp::IntegerVector end, Rcpp::List featcon, Rcpp::List cellcon, Rcpp::IntegerVector topset, V detection_limit) {
+template <class M>
+SEXP combined_qc_internal(Rcpp::RObject input, Rcpp::IntegerVector start, Rcpp::IntegerVector end, Rcpp::List featcon, Rcpp::List cellcon, Rcpp::IntegerVector topset, typename M::vector detection_limit) {
+    auto mat=beachmat::create_matrix<M>(input);
     const size_t ncells=mat->get_ncol();
     const size_t ngenes=mat->get_nrow();
 
     if (detection_limit.size()!=1) {
         throw std::runtime_error("detection limit should be a scalar");
     }
-    T limit=detection_limit[0];
+    typename M::type limit=detection_limit[0];
 
     // Defining the subset of cells for which to perform the calculation.
     const size_t firstcell=check_integer_scalar(start, "first cell index");
@@ -172,20 +174,23 @@ SEXP combined_qc_internal(M mat, Rcpp::IntegerVector start, Rcpp::IntegerVector 
 
     // Setting up per-cell statistics (for each feature control set).
     const size_t nfcontrols=featcon.size();
-    per_cell_statistics<T, V> all_PCS(n_usedcells, limit, ngenes, topset);
-    std::vector<per_cell_statistics<T, V> > control_PCS(nfcontrols);
+
+    typedef per_cell_statistics<typename M::type, typename M::vector> cell_stats;
+    cell_stats all_PCS(n_usedcells, limit, ngenes, topset);
+    std::vector<cell_stats> control_PCS(nfcontrols);
 
     for (size_t fx=0; fx<nfcontrols; ++fx) {
         Rcpp::IntegerVector current=process_subset_vector(featcon[fx], ngenes, false); // converts to zero-index.
-        control_PCS[fx]=per_cell_statistics<T, V>(n_usedcells, limit, current, topset);
+        control_PCS[fx]=cell_stats(n_usedcells, limit, current, topset);
     }
 
     // Setting up per-feature statistics (for each cell control set).
     const size_t nccontrols=cellcon.size();
     std::vector<std::vector<size_t> > chosen_ccs(n_usedcells); 
 
-    per_gene_statistics<T, V> all_PGS(ngenes, limit);
-    std::vector<per_gene_statistics<T, V> > control_PGS(nccontrols);
+    typedef per_gene_statistics<typename M::type, typename M::vector> gene_stats;
+    gene_stats all_PGS(ngenes, limit);
+    std::vector<gene_stats> control_PGS(nccontrols);
     
     for (size_t cx=0; cx<nccontrols; ++cx) {
         Rcpp::IntegerVector current=process_subset_vector(cellcon[cx], ncells, false); // converts to zero-index.
@@ -195,26 +200,18 @@ SEXP combined_qc_internal(M mat, Rcpp::IntegerVector start, Rcpp::IntegerVector 
                 chosen_ccs[cur_index - firstcell].push_back(cx); 
             }
         }
-        control_PGS[cx]=per_gene_statistics<T, V>(ngenes, limit);
+        control_PGS[cx]=gene_stats(ngenes, limit);
     }
 
     // Running through the requested stretch of cells.
-    // Very difficult in this framework to support sparsity, 
+    // Difficult in this framework to support sparsity, 
     // due to the need to consider arbitrary subsets of features,
     // so we'll limit ourselves to avoiding the copy for dense arrays.
-    V holder(ngenes);
-    auto raws=mat->set_up_raw();
-    const bool is_dense=mat->col_raw_type()=="dense";
+    beachmat::const_column<M> col_holder(mat.get(), false);
 
     for (size_t c=0; c<n_usedcells; ++c) {
-        typename V::iterator it;
-        if (is_dense) {
-            mat->get_col_raw(c + firstcell, raws);
-            it=raws.get_values_start();
-        } else {
-            it=holder.begin();
-            mat->get_col(c + firstcell, it);
-        }
+        col_holder.fill(c+firstcell);
+        auto it=col_holder.get_values();
 
         all_PCS.fill(it);
         for (size_t fx=0; fx<nfcontrols; ++fx) {
@@ -248,11 +245,9 @@ SEXP combined_qc(SEXP matrix, SEXP start, SEXP end, SEXP featcon, SEXP cellcon, 
     BEGIN_RCPP
     auto mattype=beachmat::find_sexp_type(matrix);
     if (mattype==INTSXP) {
-        auto mat=beachmat::create_integer_matrix(matrix);
-        return combined_qc_internal<int, Rcpp::IntegerVector>(mat.get(), start, end, featcon, cellcon, top, limit);
+        return combined_qc_internal<beachmat::integer_matrix>(matrix, start, end, featcon, cellcon, top, limit);
     } else if (mattype==REALSXP) {
-        auto mat=beachmat::create_numeric_matrix(matrix);
-        return combined_qc_internal<double, Rcpp::NumericVector>(mat.get(), start, end, featcon, cellcon, top, limit);
+        return combined_qc_internal<beachmat::numeric_matrix>(matrix, start, end, featcon, cellcon, top, limit);
     } else {
         throw std::runtime_error("unacceptable matrix type");
     }
@@ -261,21 +256,22 @@ SEXP combined_qc(SEXP matrix, SEXP start, SEXP end, SEXP featcon, SEXP cellcon, 
 
 /* Main loop for top_cumprop. */
 
-template <typename T, class V, class M>
-SEXP top_cumprop_internal(M mat, Rcpp::IntegerVector topset) {
+template <class M>
+SEXP top_cumprop_internal(Rcpp::RObject incoming, Rcpp::IntegerVector topset) {
+    auto mat=beachmat::create_matrix<M>(incoming);
     const size_t ncells=mat->get_ncol();
     const size_t ngenes=mat->get_nrow();
 
     check_topset(topset);
     Rcpp::NumericMatrix percentages(topset.size(), ncells);
-    V holder(ngenes);
+    typename M::vector holder(ngenes); 
 
     for (size_t c=0; c<ncells; ++c) {
-        mat->get_col(c, holder.begin());
-        double totals=std::accumulate(holder.begin(), holder.end(), T(0));
+        mat->get_col(c, holder.begin()); // need to copy as cumsum will change ordering.
+        double totals=std::accumulate(holder.begin(), holder.end(), static_cast<typename M::type>(0));
 
         auto cur_col=percentages.column(c);
-        compute_cumsum<T, V>(holder.begin(), ngenes, topset, cur_col.begin());
+        compute_cumsum<typename M::type, typename M::vector>(holder.begin(), ngenes, topset, cur_col.begin());
         for (auto& p : cur_col) { p/=totals; }
     }
 
@@ -286,11 +282,9 @@ SEXP top_cumprop(SEXP matrix, SEXP top) {
     BEGIN_RCPP
     auto mattype=beachmat::find_sexp_type(matrix);
     if (mattype==INTSXP) {
-        auto mat=beachmat::create_integer_matrix(matrix);
-        return top_cumprop_internal<int, Rcpp::IntegerVector>(mat.get(), top);
+        return top_cumprop_internal<beachmat::integer_matrix>(matrix, top);
     } else if (mattype==REALSXP) {
-        auto mat=beachmat::create_numeric_matrix(matrix);
-        return top_cumprop_internal<double, Rcpp::NumericVector>(mat.get(), top);
+        return top_cumprop_internal<beachmat::numeric_matrix>(matrix, top);
     } else {
         throw std::runtime_error("unacceptable matrix type");
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -8,7 +8,7 @@ extern "C" {
 
 static const R_CallMethodDef all_call_entries[] = {
     REGISTER(norm_exprs, 6),
-    REGISTER(ave_exprs, 6),
+    REGISTER(ave_exprs, 4),
 
     REGISTER(combined_qc, 7),
     REGISTER(top_cumprop, 2),

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -13,7 +13,8 @@ static const R_CallMethodDef all_call_entries[] = {
     REGISTER(combined_qc, 7),
     REGISTER(top_cumprop, 2),
 
-    REGISTER(sum_counts, 5),
+    REGISTER(sum_row_counts, 4),
+    REGISTER(sum_col_counts, 4),
 
     REGISTER(row_above, 4),
     REGISTER(col_above, 4),

--- a/src/num_exprs.cpp
+++ b/src/num_exprs.cpp
@@ -116,11 +116,11 @@ Rcpp::RObject col_above_internal(M mat, Rcpp::IntegerVector rows, Rcpp::IntegerV
     V incoming(mat->get_nrow());
     auto coIt=colorder.begin();
     for (const auto& c : colcopy) { 
-        auto iIt=mat->get_const_col(c, incoming.begin(), first, last);
+        mat->get_col(c, incoming.begin(), first, last);
 
         int& curcount=outcount[*(coIt++)];
         for (const auto& r : rowcopy) {
-            if (*(iIt+r) > objective) { 
+            if (incoming[r] > objective) { 
                 ++curcount;
             }
         }

--- a/src/num_exprs.cpp
+++ b/src/num_exprs.cpp
@@ -2,73 +2,47 @@
 
 #include "beachmat/integer_matrix.h"
 #include "beachmat/numeric_matrix.h"
+#include "beachmat/utils/const_column.h"
 
 #include <stdexcept>
 #include <algorithm>
 #include <vector>
 #include <utility>
 
-/* Sorting rows and column subset indices for rapid matrix access. */
-
-Rcpp::List reorganize_subset(Rcpp::IntegerVector sub1, Rcpp::IntegerVector sub2) {
-    const size_t N=sub1.size();
-    std::vector<std::pair<int, int> > paired(N);
-    for (size_t i=0; i<N; ++i) {
-        paired[i].first=sub1[i];
-        paired[i].second=i;
-    }
-    std::sort(paired.begin(), paired.end()); // Not the fastest but duplicate-safe.
-
-    Rcpp::IntegerVector sorted1(N), ordering(N);
-    for (size_t i=0; i<N; ++i) {
-        const auto& current=paired[i];
-        sorted1[i]=current.first;
-        ordering[i]=current.second;
-    }
-
-    Rcpp::IntegerVector sorted2 = Rcpp::clone(sub2).sort();
-    int first=sorted2[0], last=sorted2[sorted2.size()-1]+1; // sub2 should be non-empty by this point.
-    for (auto& x : sorted2) { 
-        x-=first;
-    }
-
-    return Rcpp::List::create(sorted1, ordering, sorted2, 
-            Rcpp::IntegerVector::create(first, last));
-}
-
 /* Function to count the incidences of particular value across each row. */
 
-template <typename T, class V, class M>
-Rcpp::RObject row_above_internal(M mat, Rcpp::IntegerVector rows, Rcpp::IntegerVector cols, Rcpp::RObject val) {
+template <class M>
+Rcpp::RObject row_above_internal(Rcpp::RObject input, Rcpp::IntegerVector rows, Rcpp::IntegerVector cols, Rcpp::RObject val) {
+    auto mat=beachmat::create_matrix<M>(input);
     Rcpp::IntegerVector outcount(rows.size());
     if (!cols.size()) { 
         return outcount;
     }
 
     // Coercing the target to the same type as the matrix.
-    V target(val);
+    typename M::vector target(val);
     if (target.size()!=1) { 
         throw std::runtime_error("value to find must be a scalar");
     }
-    const T& objective=target[0];
+    typename M::type objective=target[0];
+ 
+    int first=0, last=0;
+    if (rows.size()) {
+        first=*std::min_element(rows.begin(), rows.end());
+        last=*std::max_element(rows.begin(), rows.end())+1;
+    }
 
-    Rcpp::List reorganized=reorganize_subset(rows, cols);
-    Rcpp::IntegerVector rowcopy(reorganized[0]);
-    Rcpp::IntegerVector roworder(reorganized[1]);
-    Rcpp::IntegerVector colcopy(reorganized[2]);
-    Rcpp::IntegerVector offsets(reorganized[3]);
-    int first=offsets[0], last=offsets[1]; 
+    // Difficult to handle subsetting with const column getters,
+    // so we disable it here.
+    beachmat::const_column<M> col_holder(mat.get(), false);
 
-    V incoming(mat->get_ncol());
-    auto roIt=roworder.begin();
-    for (const auto& r : rowcopy) {
-        mat->get_row(r, incoming.begin(), first, last);
-        
-        int& curcount=outcount[*(roIt++)];
-        for (const auto& c : colcopy) {
-            if (incoming[c] > objective) { 
-                ++curcount;
-            }
+    for (const auto c : cols) {
+        col_holder.fill(c, first, last);
+        auto it=col_holder.get_values();
+        auto oIt=outcount.begin();
+        for (const auto r : rows) {
+            if (*(it + r - first) > objective) { ++(*oIt); }
+            ++oIt;
         }
     }
 
@@ -79,11 +53,9 @@ SEXP row_above(SEXP exprs, SEXP subset_row, SEXP subset_col, SEXP value) {
     BEGIN_RCPP
     auto mattype=beachmat::find_sexp_type(exprs);
     if (mattype==INTSXP) {
-        auto mat=beachmat::create_integer_matrix(exprs);
-        return row_above_internal<int, Rcpp::IntegerVector>(mat.get(), subset_row, subset_col, value);
+        return row_above_internal<beachmat::integer_matrix>(exprs, subset_row, subset_col, value);
     } else if (mattype==REALSXP) {
-        auto mat=beachmat::create_numeric_matrix(exprs);
-        return row_above_internal<double, Rcpp::NumericVector>(mat.get(), subset_row, subset_col, value);
+        return row_above_internal<beachmat::numeric_matrix>(exprs, subset_row, subset_col, value);
     } else {
         throw std::runtime_error("unacceptable matrix type");
     }
@@ -92,38 +64,36 @@ SEXP row_above(SEXP exprs, SEXP subset_row, SEXP subset_col, SEXP value) {
 
 /* Function to count the incidences of particular value across each column. */
 
-template <typename T, class V, class M>
-Rcpp::RObject col_above_internal(M mat, Rcpp::IntegerVector rows, Rcpp::IntegerVector cols, Rcpp::RObject val) {
+template <class M>
+Rcpp::RObject col_above_internal(Rcpp::RObject input, Rcpp::IntegerVector rows, Rcpp::IntegerVector cols, Rcpp::RObject val) {
+    auto mat=beachmat::create_matrix<M>(input);
     Rcpp::IntegerVector outcount(cols.size());
     if (!rows.size()) { 
         return outcount;
     }
 
     // Coercing the target to the same type as the matrix.
-    V target(val);
+    typename M::vector target(val);
     if (target.size()!=1) { 
         throw std::runtime_error("value to find must be a scalar");
     }
-    const T& objective=target[0];
+    typename M::type objective=target[0];
 
-    Rcpp::List reorganized=reorganize_subset(cols, rows);
-    Rcpp::IntegerVector colcopy(reorganized[0]);
-    Rcpp::IntegerVector colorder(reorganized[1]);
-    Rcpp::IntegerVector rowcopy(reorganized[2]);
-    Rcpp::IntegerVector offsets(reorganized[3]);
-    int first=offsets[0], last=offsets[1]; 
- 
-    V incoming(mat->get_nrow());
-    auto coIt=colorder.begin();
-    for (const auto& c : colcopy) { 
-        mat->get_col(c, incoming.begin(), first, last);
+    int first=0, last=0;
+    if (rows.size()) {
+        first=*std::min_element(rows.begin(), rows.end());
+        last=*std::max_element(rows.begin(), rows.end())+1;
+    }
 
-        int& curcount=outcount[*(coIt++)];
-        for (const auto& r : rowcopy) {
-            if (incoming[r] > objective) { 
-                ++curcount;
-            }
+    beachmat::const_column<M> col_holder(mat.get(), false);
+    auto oIt=outcount.begin();
+    for (const auto c : cols) { 
+        col_holder.fill(c, first, last);
+        auto it=col_holder.get_values();
+        for (const auto r : rows) {
+            if (*(it + r - first) > objective) { ++(*oIt); }
         }
+        ++oIt;
     }
 
     return outcount;
@@ -133,11 +103,9 @@ SEXP col_above(SEXP exprs, SEXP subset_row, SEXP subset_col, SEXP value) {
     BEGIN_RCPP
     auto mattype=beachmat::find_sexp_type(exprs);
     if (mattype==INTSXP) {
-        auto mat=beachmat::create_integer_matrix(exprs);
-        return col_above_internal<int, Rcpp::IntegerVector>(mat.get(), subset_row, subset_col, value);
+        return col_above_internal<beachmat::integer_matrix>(exprs, subset_row, subset_col, value);
     } else if (mattype==REALSXP) {
-        auto mat=beachmat::create_numeric_matrix(exprs);
-        return col_above_internal<double, Rcpp::NumericVector>(mat.get(), subset_row, subset_col, value);
+        return col_above_internal<beachmat::numeric_matrix>(exprs, subset_row, subset_col, value);
     } else {
         throw std::runtime_error("unacceptable matrix type");
     }

--- a/src/scater.h
+++ b/src/scater.h
@@ -17,7 +17,9 @@ SEXP combined_qc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 SEXP top_cumprop(SEXP, SEXP);
 
 
-SEXP sum_counts(SEXP, SEXP, SEXP, SEXP, SEXP);
+SEXP sum_row_counts(SEXP, SEXP, SEXP, SEXP);
+
+SEXP sum_col_counts(SEXP, SEXP, SEXP, SEXP);
 
 
 SEXP row_above(SEXP, SEXP, SEXP, SEXP);

--- a/src/scater.h
+++ b/src/scater.h
@@ -9,7 +9,7 @@ extern "C" {
 
 SEXP norm_exprs(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
-SEXP ave_exprs(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+SEXP ave_exprs(SEXP, SEXP, SEXP, SEXP);
 
 
 SEXP combined_qc(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);

--- a/src/sum_counts.cpp
+++ b/src/sum_counts.cpp
@@ -7,89 +7,178 @@
 #include <stdexcept>
 #include <vector>
 
+std::vector<Rcpp::IntegerVector> create_summation(Rcpp::List Sumset) {
+    const size_t nsummations=Sumset.size();
+    std::vector<Rcpp::IntegerVector> summation_set(Sumset.size());
+    for (size_t fx=0; fx<nsummations; ++fx) {
+        summation_set[fx]=Sumset[fx];
+    }
+    return summation_set;
+}
+
+/***************************
+ * Summing across features *
+ ***************************/
+
 template <class V, class O, class M>
-Rcpp::RObject sum_counts_internal(M mat, O out, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index, bool sum_by_row) {
+Rcpp::RObject sum_row_counts_internal(M mat, O out, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index) {
     const size_t ncells=mat->get_ncol();
     const size_t ngenes=mat->get_nrow();
 
-    if (sum_by_row) {
-        V holder_in(ngenes), holder_out(summable_set.size());
-        if (end_index > ncells) {
-            throw std::runtime_error("end index out of range");
+    V holder_in(ngenes), holder_out(summable_set.size());
+    if (end_index > ncells) {
+        throw std::runtime_error("end index out of range");
+    }
+
+    // Specializing for dense arrays to avoid copies.
+    // Again, quite difficult to support sparsity due to the
+    // need for arbitrary indexing of rows.
+    auto raws=mat->set_up_raw();
+    const bool is_dense=(mat->col_raw_type()=="dense");
+
+    for (size_t c=start_index; c<end_index; ++c) {
+        typename V::iterator it;
+        if (is_dense) {
+            mat->get_col_raw(c, raws);
+            it=raws.get_values_start();
+
+        } else {
+            it=holder_in.begin();
+            mat->get_col(c, it);
         }
 
-        for (size_t c=start_index; c<end_index; ++c) {
-            mat->get_col(c, holder_in.begin());
-    
-            auto ssIt=summable_set.begin();
-            for (auto oIt=holder_out.begin(); oIt!=holder_out.end(); ++oIt, ++ssIt) {
-                const auto& curset=(*ssIt);
-                auto& curval=(*oIt=0);
-                for (auto feat : curset) {
-                    curval+=holder_in[feat];
-                }
+        auto ssIt=summable_set.begin();
+        for (auto& curval : holder_out) {
+            const auto& curset=(*ssIt);
+            curval=0;
+            for (auto feat : curset) {
+                curval += *(it + feat);
             }
-            out->set_col(c - start_index, holder_out.begin());
+            ++ssIt;
         }
 
-    } else {
-        V holder_in(ncells), holder_out(summable_set.size());
-        if (end_index > ngenes) {
-            throw std::runtime_error("end index out of range");
-        }
-
-        for (size_t g=start_index; g<end_index; ++g) {
-            mat->get_row(g, holder_in.begin());
-    
-            auto ssIt=summable_set.begin();
-            for (auto oIt=holder_out.begin(); oIt!=holder_out.end(); ++oIt, ++ssIt) {
-                const auto& curset=(*ssIt);
-                auto& curval=(*oIt=0);
-                for (auto cell : curset) {
-                    curval+=holder_in[cell];
-                }
-            }
-            out->set_row(g - start_index, holder_out.begin());
-        }
+        out->set_col(c - start_index, holder_out.begin());
     }
     return out->yield();
 }
 
-SEXP sum_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end, SEXP by_row) {
+SEXP sum_row_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end) {
     BEGIN_RCPP
-    Rcpp::List Sumset(sumset);
-    std::vector<Rcpp::IntegerVector> summation_set(Sumset.size());
+
+    auto summation_set=create_summation(sumset);
     const size_t nsummations=summation_set.size();
-    for (size_t fx=0; fx<nsummations; ++fx) {
-        summation_set[fx]=Sumset[fx];
-    }
 
     // Determining the type and amount of work to do.
-    bool sum_by_row=check_logical_scalar(by_row, "by-row specification");
     size_t start_index=check_integer_scalar(job_start, "start index");
     size_t end_index=check_integer_scalar(job_end, "end index");
     if (end_index < start_index) { throw std::runtime_error("start index is less than end index"); }
-    
-    // Determining the dimensionality of the output.
-    const size_t niters=end_index - start_index;
-    const size_t out_nrow=(sum_by_row ? nsummations : niters);
-    const size_t out_ncol=(sum_by_row ? niters : nsummations);
+    const size_t ncells=end_index - start_index;
 
     auto mattype=beachmat::find_sexp_type(counts);
     if (mattype==INTSXP) {
         auto mat=beachmat::create_integer_matrix(counts);
         beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
-        auto out=beachmat::create_integer_output(out_nrow, out_ncol, OPARAM);
-        return sum_counts_internal<Rcpp::IntegerVector>(mat.get(), out.get(), summation_set, start_index, end_index, sum_by_row);
+        auto out=beachmat::create_integer_output(nsummations, ncells, OPARAM);
+        return sum_row_counts_internal<Rcpp::IntegerVector>(mat.get(), out.get(), summation_set, start_index, end_index);
 
     } else if (mattype==REALSXP) {
         auto mat=beachmat::create_numeric_matrix(counts);
         beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
-        auto out=beachmat::create_numeric_output(out_nrow, out_ncol, OPARAM);
-        return sum_counts_internal<Rcpp::NumericVector>(mat.get(), out.get(), summation_set, start_index, end_index, sum_by_row);
+        auto out=beachmat::create_numeric_output(nsummations, ncells, OPARAM);
+        return sum_row_counts_internal<Rcpp::NumericVector>(mat.get(), out.get(), summation_set, start_index, end_index);
 
     } else {
         throw std::runtime_error("unacceptable matrix type");
     }
     END_RCPP
+} 
+
+/************************
+ * Summing across cells *
+ ************************/
+
+template <class V, class O, class M>
+Rcpp::RObject sum_col_counts_internal(M mat, O out, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index) {
+    const size_t ncells=mat->get_ncol();
+    const size_t ngenes=mat->get_nrow();
+
+    V holder_in(ngenes), holder_out(ngenes);
+    if (end_index > ngenes) {
+        throw std::runtime_error("end index out of range");
+    }
+
+    auto raws=mat->set_up_raw();
+    const bool is_dense=(mat->col_raw_type()=="dense");
+    const bool is_sparse=(mat->col_raw_type()=="sparse");
+
+    size_t i_summed=0;
+    for (const auto& curset : summable_set) {
+        std::fill(holder_out.begin()+start_index, holder_out.begin()+end_index, 0);
+
+        // Specialized for sparse matrices.
+        if (is_sparse) {
+            for (auto cell : curset) {
+                mat->get_col_raw(cell, raws, start_index, end_index);
+                auto n=raws.get_n();
+                auto idx=raws.get_structure_start();
+                auto val=raws.get_values_start();
+
+                for (size_t i=0; i<raws.get_n(); ++i, ++idx, ++val) {
+                    holder_out[*idx]+=*val;
+                }
+            }
+
+        } else {
+            for (auto cell : curset) {
+                typename V::iterator it;
+                if (is_dense) {
+                    mat->get_col_raw(cell, raws);
+                    it=raws.get_values_start();
+                } else {
+                    it=holder_in.begin();
+                    mat->get_col(cell, it+start_index, start_index, end_index);
+                }
+
+                for (size_t i=start_index; i<end_index; ++i) {
+                    holder_out[i] += *(it + i);
+                }
+            }
+        }
+
+        out->set_col(i_summed, holder_out.begin()+start_index);
+        ++i_summed;
+    }
+    return out->yield();
 }
+
+SEXP sum_col_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end) {
+    BEGIN_RCPP
+
+    auto summation_set=create_summation(sumset);
+    const size_t nsummations=summation_set.size();
+
+    // Determining the type and amount of work to do.
+    size_t start_index=check_integer_scalar(job_start, "start index");
+    size_t end_index=check_integer_scalar(job_end, "end index");
+    if (end_index < start_index) { throw std::runtime_error("start index is less than end index"); }
+    const size_t ngenes=end_index - start_index;
+
+    auto mattype=beachmat::find_sexp_type(counts);
+    if (mattype==INTSXP) {
+        auto mat=beachmat::create_integer_matrix(counts);
+        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
+        auto out=beachmat::create_integer_output(ngenes, nsummations, OPARAM);
+        return sum_col_counts_internal<Rcpp::IntegerVector>(mat.get(), out.get(), summation_set, start_index, end_index);
+
+    } else if (mattype==REALSXP) {
+        auto mat=beachmat::create_numeric_matrix(counts);
+        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
+        auto out=beachmat::create_numeric_output(ngenes, nsummations, OPARAM);
+        return sum_col_counts_internal<Rcpp::NumericVector>(mat.get(), out.get(), summation_set, start_index, end_index);
+
+    } else {
+        throw std::runtime_error("unacceptable matrix type");
+    }
+    END_RCPP
+} 
+

--- a/src/sum_counts.cpp
+++ b/src/sum_counts.cpp
@@ -19,14 +19,14 @@ Rcpp::RObject sum_counts_internal(M mat, O out, const std::vector<Rcpp::IntegerV
         }
 
         for (size_t c=start_index; c<end_index; ++c) {
-            auto cIt=mat->get_const_col(c, holder_in.begin());
+            mat->get_col(c, holder_in.begin());
     
             auto ssIt=summable_set.begin();
             for (auto oIt=holder_out.begin(); oIt!=holder_out.end(); ++oIt, ++ssIt) {
                 const auto& curset=(*ssIt);
                 auto& curval=(*oIt=0);
                 for (auto feat : curset) {
-                    curval+=*(cIt + feat);                
+                    curval+=holder_in[feat];
                 }
             }
             out->set_col(c - start_index, holder_out.begin());
@@ -78,20 +78,14 @@ SEXP sum_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end, SEXP by
     auto mattype=beachmat::find_sexp_type(counts);
     if (mattype==INTSXP) {
         auto mat=beachmat::create_integer_matrix(counts);
-       
-        beachmat::output_param OPARAM(mat->get_matrix_type(), true, true);
-        OPARAM.optimize_chunk_dims(out_nrow, out_ncol);
+        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
         auto out=beachmat::create_integer_output(out_nrow, out_ncol, OPARAM);
-
         return sum_counts_internal<Rcpp::IntegerVector>(mat.get(), out.get(), summation_set, start_index, end_index, sum_by_row);
 
     } else if (mattype==REALSXP) {
         auto mat=beachmat::create_numeric_matrix(counts);
-
-        beachmat::output_param OPARAM(mat->get_matrix_type(), true, true);
-        OPARAM.optimize_chunk_dims(out_nrow, out_ncol);
+        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
         auto out=beachmat::create_numeric_output(out_nrow, out_ncol, OPARAM);
-
         return sum_counts_internal<Rcpp::NumericVector>(mat.get(), out.get(), summation_set, start_index, end_index, sum_by_row);
 
     } else {

--- a/src/sum_counts.cpp
+++ b/src/sum_counts.cpp
@@ -2,6 +2,7 @@
 
 #include "beachmat/integer_matrix.h"
 #include "beachmat/numeric_matrix.h"
+#include "beachmat/utils/const_column.h"
 #include "utils.h"
 
 #include <stdexcept>
@@ -20,34 +21,32 @@ std::vector<Rcpp::IntegerVector> create_summation(Rcpp::List Sumset) {
  * Summing across features *
  ***************************/
 
-template <class V, class O, class M>
-Rcpp::RObject sum_row_counts_internal(M mat, O out, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index) {
+template <class M, class O>
+Rcpp::RObject sum_row_counts_internal(Rcpp::RObject input, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index) {
+    auto mat=beachmat::create_matrix<M>(input);
     const size_t ncells=mat->get_ncol();
     const size_t ngenes=mat->get_nrow();
-
-    V holder_in(ngenes), holder_out(summable_set.size());
+    
+    const size_t nsummations=summable_set.size();
+    typename M::vector holder_out(nsummations);
     if (end_index > ncells) {
         throw std::runtime_error("end index out of range");
     }
 
+    beachmat::output_param OPARAM(mat.get());
+    const size_t njobs=end_index - start_index;
+    auto out=beachmat::create_output<O>(nsummations, njobs, OPARAM);
+
     // Specializing for dense arrays to avoid copies.
     // Again, quite difficult to support sparsity due to the
     // need for arbitrary indexing of rows.
-    auto raws=mat->set_up_raw();
-    const bool is_dense=(mat->col_raw_type()=="dense");
+    beachmat::const_column<M> col_holder(mat.get(), false);
 
     for (size_t c=start_index; c<end_index; ++c) {
-        typename V::iterator it;
-        if (is_dense) {
-            mat->get_col_raw(c, raws);
-            it=raws.get_values_start();
-
-        } else {
-            it=holder_in.begin();
-            mat->get_col(c, it);
-        }
-
+        col_holder.fill(c);
+        auto it=col_holder.get_values();
         auto ssIt=summable_set.begin();
+
         for (auto& curval : holder_out) {
             const auto& curset=(*ssIt);
             curval=0;
@@ -76,16 +75,12 @@ SEXP sum_row_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end) {
 
     auto mattype=beachmat::find_sexp_type(counts);
     if (mattype==INTSXP) {
-        auto mat=beachmat::create_integer_matrix(counts);
-        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
-        auto out=beachmat::create_integer_output(nsummations, ncells, OPARAM);
-        return sum_row_counts_internal<Rcpp::IntegerVector>(mat.get(), out.get(), summation_set, start_index, end_index);
+        return sum_row_counts_internal<beachmat::integer_matrix,
+           beachmat::integer_output>(counts, summation_set, start_index, end_index);
 
     } else if (mattype==REALSXP) {
-        auto mat=beachmat::create_numeric_matrix(counts);
-        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
-        auto out=beachmat::create_numeric_output(nsummations, ncells, OPARAM);
-        return sum_row_counts_internal<Rcpp::NumericVector>(mat.get(), out.get(), summation_set, start_index, end_index);
+        return sum_row_counts_internal<beachmat::numeric_matrix,
+           beachmat::numeric_output>(counts, summation_set, start_index, end_index);
 
     } else {
         throw std::runtime_error("unacceptable matrix type");
@@ -97,50 +92,40 @@ SEXP sum_row_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end) {
  * Summing across cells *
  ************************/
 
-template <class V, class O, class M>
-Rcpp::RObject sum_col_counts_internal(M mat, O out, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index) {
+template <class M, class O>
+Rcpp::RObject sum_col_counts_internal(Rcpp::RObject input, const std::vector<Rcpp::IntegerVector>& summable_set, size_t start_index, size_t end_index) {
+    auto mat=beachmat::create_matrix<M>(input);
     const size_t ncells=mat->get_ncol();
     const size_t ngenes=mat->get_nrow();
 
-    V holder_in(ngenes), holder_out(ngenes);
+    typename M::vector holder_out(ngenes);
     if (end_index > ngenes) {
         throw std::runtime_error("end index out of range");
     }
+    beachmat::const_column<M> col_holder(mat.get());
 
-    auto raws=mat->set_up_raw();
-    const bool is_dense=(mat->col_raw_type()=="dense");
-    const bool is_sparse=(mat->col_raw_type()=="sparse");
+    beachmat::output_param OPARAM(mat.get());
+    const size_t njobs=end_index - start_index;
+    auto out=beachmat::create_output<O>(njobs, summable_set.size(), OPARAM);
 
     size_t i_summed=0;
     for (const auto& curset : summable_set) {
         std::fill(holder_out.begin()+start_index, holder_out.begin()+end_index, 0);
 
-        // Specialized for sparse matrices.
-        if (is_sparse) {
-            for (auto cell : curset) {
-                mat->get_col_raw(cell, raws, start_index, end_index);
-                auto n=raws.get_n();
-                auto idx=raws.get_structure_start();
-                auto val=raws.get_values_start();
+        for (auto cell : curset) {
+            col_holder.fill(cell, start_index, end_index);
+            auto val=col_holder.get_values();
 
-                for (size_t i=0; i<raws.get_n(); ++i, ++idx, ++val) {
+            // Specialized for sparse matrices.
+            if (col_holder.is_sparse()) {
+                auto n=col_holder.get_n();
+                auto idx=col_holder.get_indices();
+                for (size_t i=0; i<n; ++i, ++idx, ++val) {
                     holder_out[*idx]+=*val;
                 }
-            }
-
-        } else {
-            for (auto cell : curset) {
-                typename V::iterator it;
-                if (is_dense) {
-                    mat->get_col_raw(cell, raws);
-                    it=raws.get_values_start();
-                } else {
-                    it=holder_in.begin();
-                    mat->get_col(cell, it+start_index, start_index, end_index);
-                }
-
-                for (size_t i=start_index; i<end_index; ++i) {
-                    holder_out[i] += *(it + i);
+            } else {
+                for (size_t i=start_index; i<end_index; ++i, ++val) {
+                    holder_out[i] += *val;
                 }
             }
         }
@@ -165,16 +150,12 @@ SEXP sum_col_counts (SEXP counts, SEXP sumset, SEXP job_start, SEXP job_end) {
 
     auto mattype=beachmat::find_sexp_type(counts);
     if (mattype==INTSXP) {
-        auto mat=beachmat::create_integer_matrix(counts);
-        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
-        auto out=beachmat::create_integer_output(ngenes, nsummations, OPARAM);
-        return sum_col_counts_internal<Rcpp::IntegerVector>(mat.get(), out.get(), summation_set, start_index, end_index);
+        return sum_col_counts_internal<beachmat::integer_matrix,
+           beachmat::integer_output>(counts, summation_set, start_index, end_index);
 
     } else if (mattype==REALSXP) {
-        auto mat=beachmat::create_numeric_matrix(counts);
-        beachmat::output_param OPARAM(mat->get_class(), mat->get_package());
-        auto out=beachmat::create_numeric_output(ngenes, nsummations, OPARAM);
-        return sum_col_counts_internal<Rcpp::NumericVector>(mat.get(), out.get(), summation_set, start_index, end_index);
+        return sum_col_counts_internal<beachmat::numeric_matrix,
+           beachmat::numeric_output>(counts, summation_set, start_index, end_index);
 
     } else {
         throw std::runtime_error("unacceptable matrix type");

--- a/tests/testthat/test-calc-ave.R
+++ b/tests/testthat/test-calc-ave.R
@@ -72,15 +72,22 @@ test_that("calcAverage responds to other choices", {
     whee_counts <- calcAverage(whee, exprs_values="whee")
     expect_identical(whee_counts, ave_counts)
 
-    ## Responsive to paralellization.
+    ## Responsive to parallelization.
     expect_equal(ave_counts, calcAverage(original, BPPARAM=MulticoreParam(2)))
-    expect_equal(ave_counts, calcAverage(original, BPPARAM=SnowParam(3)))
+    expect_equal(ave_counts, calcAverage(original, BPPARAM=MulticoreParam(3)))
 
-    ## Repeating with a sparse matrix.    
+    ## Repeating with a sparse matrix, to check that the specialized code is correct.
     sparsified <- original
     counts(sparsified) <- as(counts(original), "dgCMatrix")
-    ave_counts <- calcAverage(sparsified)
-    expect_equal(ave_counts, calcAverage(original, use_size_factors=FALSE))  
+    expect_equal(ave_counts, calcAverage(sparsified))
+    expect_equal(calcAverage(original, subset_row=30:20),
+        calcAverage(sparsified, subset_row=30:20))
+
+    unknown <- original
+    counts(unknown) <- as(counts(original), "dgTMatrix")
+    expect_equal(ave_counts, calcAverage(unknown))
+    expect_equal(calcAverage(unknown, subset_row=25:15),
+         calcAverage(original, subset_row=25:15))
 })
 
 test_that("calcAverage handles silly inputs", {

--- a/tests/testthat/test-calc-nexprs.R
+++ b/tests/testthat/test-calc-nexprs.R
@@ -34,6 +34,7 @@ test_that("nexprs works on a sparse matrix", {
     sparsified <- original
     counts(sparsified) <- as(counts(original), "dgCMatrix")
     expect_equal(nexprs(sparsified), Matrix::colSums(counts(sparsified) > 0))
+    expect_equal(nexprs(sparsified, byrow=TRUE), Matrix::rowSums(counts(sparsified) > 0))
     expect_equal(nexprs(sparsified), nexprs(counts(sparsified)))
 })
 

--- a/tests/testthat/test-feat-proc.R
+++ b/tests/testthat/test-feat-proc.R
@@ -42,6 +42,12 @@ test_that("by-feature count summarization behaves with odd inputs", {
     expect_s4_class(spack, "dgCMatrix")
     expect_equal(ref, as.matrix(spack))
 
+    unknown <- sce
+    counts(unknown) <- as(counts(unknown), "dgTMatrix")
+    spack <- sumCountsAcrossFeatures(unknown, ids)
+    expect_true(is.matrix(spack))
+    expect_equivalent(ref, as.matrix(spack))
+
     # Handles parallelization properly.
     alt <- sumCountsAcrossFeatures(sce, ids, BPPARAM=BiocParallel::MulticoreParam(2))
     expect_identical(alt, ref)
@@ -88,6 +94,12 @@ test_that("by-cell count summarization behaves with odd inputs", {
     spack <- sumCountsAcrossCells(sparsified, ids)
     expect_s4_class(spack, "dgCMatrix")
     expect_equal(ref, as.matrix(spack))
+
+    unknown <- sce
+    counts(unknown) <- as(counts(unknown), "dgTMatrix")
+    spack <- sumCountsAcrossCells(unknown, ids)
+    expect_true(is.matrix(spack))
+    expect_equivalent(ref, as.matrix(spack))
 
     # Handles parallelization properly.
     alt <- sumCountsAcrossCells(sce, ids, BPPARAM=BiocParallel::MulticoreParam(2))

--- a/tests/testthat/test-plot-scater.R
+++ b/tests/testthat/test-plot-scater.R
@@ -30,7 +30,6 @@ test_that("plotScater works as expected", {
 })
 
 test_that("plotScater's underlying C++ code works as expected", {
-# library(scater); library(testthat); source("setup-sce.R"); example_sce <- sce
     REFFUN <- function(x, top) {
         prop <- cumsum(sort(x, decreasing=TRUE))/sum(x)
         prop[pmin(top, length(x))]
@@ -43,6 +42,14 @@ test_that("plotScater's underlying C++ code works as expected", {
 
     out <- .Call(scater:::cxx_top_cumprop, assay(example_sce), 1:20*5)
     ref <- apply(assay(example_sce), 2, REFFUN, top=1:20*5)
+    colnames(out) <- colnames(ref)
+    expect_equal(out, ref)
+
+    # Handles sparse matrices.
+    library(Matrix)
+    spmat <- as(assay(example_sce), "dgCMatrix")
+    out <- .Call(scater:::cxx_top_cumprop, spmat, 1:100)
+    ref <- apply(spmat, 2, REFFUN, top=1:100)
     colnames(out) <- colnames(ref)
     expect_equal(out, ref)
 


### PR DESCRIPTION
- Switch to header-only beachmat version 2 to avoid need for manual linkage.
- Simplify integer/numeric templating.
- Refactoring of some code for simplicity and to better exploit raw data structure.
- Add more tests everywhere.