### PR TITLE
Convert factor to character in uniquifyFeatureNames

### DIFF
--- a/R/uniquifyFeatureNames.R
+++ b/R/uniquifyFeatureNames.R
@@ -26,9 +26,8 @@ uniquifyFeatureNames <- function(ID, names) {
     if (length(ID)!=length(names)) {
         stop("lengths of 'ID' and 'names' must be equal")
     }
-    if (is.factor(names)) {
-        names <- as.character(names)
-    }
+    names <- as.character(names)
+    ID <- as.character(ID)
     missing.name <- is.na(names)
     names[missing.name] <- ID[missing.name]
     dup.name <- names %in% names[duplicated(names)]

--- a/R/uniquifyFeatureNames.R
+++ b/R/uniquifyFeatureNames.R
@@ -26,6 +26,9 @@ uniquifyFeatureNames <- function(ID, names) {
     if (length(ID)!=length(names)) {
         stop("lengths of 'ID' and 'names' must be equal")
     }
+    if (is.factor(names)) {
+        names <- as.character(names)
+    }
     missing.name <- is.na(names)
     names[missing.name] <- ID[missing.name]
     dup.name <- names %in% names[duplicated(names)]

--- a/tests/testthat/test-feat-proc.R
+++ b/tests/testthat/test-feat-proc.R
@@ -243,11 +243,16 @@ test_that("we can uniquify the feature names", {
     all.genes <- sample(c(LETTERS, LETTERS[1:5], NA, NA))
     all.ids <- paste0("GENE", seq_along(all.genes))
     out <- uniquifyFeatureNames(all.ids, all.genes)
-
+    out.factor.names <- uniquifyFeatureNames(all.ids, factor(all.genes))
+    out.factor.id <- uniquifyFeatureNames(factor(all.ids), all.genes)
+    
     lost <- is.na(all.genes)
     expect_identical(out[lost], all.ids[lost])
     dup <- all.genes %in% all.genes[duplicated(all.genes)]
     expect_identical(out[!dup & !lost], all.genes[!dup & !lost])
     expect_identical(out[dup & !lost], paste0(all.genes, "_", all.ids)[dup & !lost])
+    
+    expect_identical(out, out.factor.names)
+    expect_identical(out, out.factor.id)
 })
 


### PR DESCRIPTION
Currently, 
```
uniquifyFeatureNames(ID=paste0("ENSG0000000", 1:5),
                     names=factor(c("A", NA, "B", "C", "A")))
```
gives 
```
[1] <NA> <NA> B    C    <NA>
Levels: A B C
```
without complaining, which I think is not what I would expect.