### PR TITLE
add point_shape argument

### DIFF
--- a/R/plotPlatePosition.R
+++ b/R/plotPlatePosition.R
@@ -16,6 +16,8 @@
 #' @param theme_size Numeric scalar, see \code{?"\link{scater-plot-args}"} for details.
 #' @param point_alpha Numeric scalar specifying the transparency of the points, see \code{?"\link{scater-plot-args}"} for details.
 #' @param point_size Numeric scalar specifying the size of the points, see \code{?"\link{scater-plot-args}"} for details.
+#' @param point_shape An integer, or a string specifying the shape
+#' of the points. See \code{?"\link{scater-plot-args}"} for details. 
 #' @param other_fields Additional cell-based fields to include in the data.frame, see \code{?"\link{scater-plot-args}"} for details.
 #' @param swap_rownames Column name of \code{rowData(object)} to be used to 
 #'  identify features instead of \code{rownames(object)} when labelling plot 

--- a/R/plotPlatePosition.R
+++ b/R/plotPlatePosition.R
@@ -57,7 +57,7 @@ plotPlatePosition <- function(object, plate_position = NULL,
     colour_by = color_by, size_by = NULL, shape_by = NULL, order_by = NULL,
     by_exprs_values = "logcounts", 
     add_legend = TRUE, theme_size = 24, point_alpha = 0.6,
-    point_size = 24, other_fields=list(),
+    point_size = 24, point_shape = 19, other_fields=list(),
     swap_rownames = NULL, color_by = NULL) 
 {
     ## check object is SingleCellExperiment object
@@ -100,7 +100,7 @@ plotPlatePosition <- function(object, plate_position = NULL,
     ## make the plot with appropriate colours.
     plot_out <- ggplot(df_to_plot, aes_string(x="X", y="Y"))
 
-    point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size)
+    point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
     plot_out <- plot_out + do.call(geom_point, point_out$args)
 
     if (!is.null(colour_by)) {

--- a/R/plotReducedDim.R
+++ b/R/plotReducedDim.R
@@ -199,7 +199,7 @@ plotReducedDim <- function(
 paired_reddim_plot <- function(df_to_plot, to_plot, dimred, percentVar = NULL,
         colour_by=NULL, shape_by=NULL, size_by=NULL,
         label_format=c("%s %i", " (%i%%)"),
-        add_legend = TRUE, theme_size = 10, point_alpha = 0.6, point_size = NULL,
+        add_legend = TRUE, theme_size = 10, point_alpha = 0.6, point_size = NULL, point_shape = NULL,
         rasterise = FALSE
     ) {
 
@@ -231,7 +231,8 @@ paired_reddim_plot <- function(df_to_plot, to_plot, dimred, percentVar = NULL,
 
     ## Setting up the point addition with various aesthetics.
     point_out <- .get_point_args(
-        colour_by, shape_by, size_by, alpha = point_alpha, size = point_size
+        colour_by, shape_by, size_by, alpha = point_alpha, size = point_size,
+        shape = point_shape
     )
     plot_out <- plot_out + do.call(geom_point, point_out$args)
     if (!is.null(colour_by)) {

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -12,8 +12,9 @@
 #' Defaults to 0.6.}
 #' \item{\code{point_size}:}{Numeric scalar, specifying the size of the points.
 #' Defaults to \code{NULL}.}
-#' \item{\code{point_shape}:}{Numeric scalar, specifying the size of the points.
-#' Defaults to \code{19}.}
+#' \item{\code{point_shape}:}{An integer, or a string specifying the shape
+#' of the points. Details see \code{vignette("ggplot2-specs")}. Defaults to
+#' \code{19}.}
 #' \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 #' This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 #' The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -12,6 +12,8 @@
 #' Defaults to 0.6.}
 #' \item{\code{point_size}:}{Numeric scalar, specifying the size of the points.
 #' Defaults to \code{NULL}.}
+#' \item{\code{point_shape}:}{Numeric scalar, specifying the size of the points.
+#' Defaults to \code{19}.}
 #' \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 #' This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 #' The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}
@@ -58,7 +60,7 @@ NULL
                              colour_by = NULL, shape_by = NULL, size_by = NULL, fill_by = NULL,
                              show_median = FALSE, show_violin = TRUE, show_smooth = FALSE, show_se = TRUE,
                             #  show_points = TRUE,
-                             theme_size = 10, point_alpha = 0.6, point_size = NULL, add_legend = TRUE,
+                             theme_size = 10, point_alpha = 0.6, point_size = NULL, point_shape = 19, add_legend = TRUE,
                              point_FUN = NULL, jitter_type = "swarm",
                              rasterise = FALSE)
 # Internal ggplot-creating function to plot anything that involves points.
@@ -94,7 +96,7 @@ NULL
         }
 
         # Adding points.
-        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size)
+        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
         if (is.null(point_FUN)) {
             if (jitter_type=="swarm") {
                 point_FUN <- function(...) geom_quasirandom(..., width=0.4, groupOnX=TRUE, bandwidth=1)
@@ -114,7 +116,7 @@ NULL
         plot_out <- ggplot(object, aes_string(x="X", y="Y")) + xlab(xlab) + ylab(ylab)
 
         # Adding points.
-        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size)
+        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
         if (is.null(point_FUN)) {
             point_FUN <- geom_point
         }
@@ -159,7 +161,7 @@ NULL
                                          data=summary.data, colour = 'grey60', size = 0.5, fill='grey90')
 
         # Adding points.
-        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size)
+        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
         if (is.null(point_FUN)) {
             point_FUN <- geom_point
         }
@@ -190,7 +192,7 @@ NULL
 }
 
 #' @importFrom ggplot2 aes_string
-.get_point_args <- function(colour_by, shape_by, size_by, alpha=0.65, size=NULL) 
+.get_point_args <- function(colour_by, shape_by, size_by, alpha=0.65, size=NULL, shape = NULL) 
 ## Note the use of colour instead of fill when shape_by is set, as not all shapes have fill.
 ## (Fill is still the default as it looks nicer.)
 {
@@ -220,7 +222,7 @@ NULL
         geom_args$fill <- "grey20"
     }
     if (is.null(shape_by)) {
-        geom_args$shape <- 19
+        geom_args$shape <- shape
     }
     if (is.null(size_by)) {
         geom_args$size <- size

--- a/man/plotPlatePosition.Rd
+++ b/man/plotPlatePosition.Rd
@@ -48,6 +48,9 @@ for use in point aesthetics - see the \code{exprs_values} argument in \code{?\li
 
 \item{point_size}{Numeric scalar specifying the size of the points, see \code{?"\link{scater-plot-args}"} for details.}
 
+\item{point_shape}{An integer, or a string specifying the shape
+of the points. See \code{?"\link{scater-plot-args}"} for details.}
+
 \item{other_fields}{Additional cell-based fields to include in the data.frame, see \code{?"\link{scater-plot-args}"} for details.}
 
 \item{swap_rownames}{Column name of \code{rowData(object)} to be used to 

--- a/man/plotPlatePosition.Rd
+++ b/man/plotPlatePosition.Rd
@@ -16,6 +16,7 @@ plotPlatePosition(
   theme_size = 24,
   point_alpha = 0.6,
   point_size = 24,
+  point_shape = 19,
   other_fields = list(),
   swap_rownames = NULL,
   color_by = NULL

--- a/man/retrieveCellInfo.Rd
+++ b/man/retrieveCellInfo.Rd
@@ -22,8 +22,8 @@ Alternatively, a data.frame, \linkS4class{DataFrame} or an \link{AsIs} vector.}
 
 \item{exprs_values}{String or integer scalar specifying the assay from which expression values should be extracted.}
 
-\item{swap_rownames}{Column name of \code{rowData(object)} to be used to 
-identify features instead of \code{rownames(object)} when labelling plot 
+\item{swap_rownames}{Column name of \code{rowData(object)} to be used to
+identify features instead of \code{rownames(object)} when labelling plot
 elements.}
 }
 \value{
@@ -44,16 +44,16 @@ This allows downstream visualization functions to accommodate arbitrary inputs f
 
 Given a character string in \code{by}, this function will:
 \enumerate{
-\item Search \code{\link{colData}} for a column named \code{by}, 
+\item Search \code{\link{colData}} for a column named \code{by},
 and return the corresponding field as the output \code{value}.
 We do not consider nested elements within the \code{colData}.
-\item Search \code{\link{assay}(x, exprs_values)} for a row named \code{by}, 
+\item Search \code{\link{assay}(x, exprs_values)} for a row named \code{by},
 and return the expression vector for this feature as the output \code{value}.
 \item Search each alternative experiment in \code{\link{altExps}(x)} for a row names \code{by},
 and return the expression vector for this feature at \code{exprs_values} as the output \code{value}.
 }
 Any match will cause the function to return without considering later possibilities.
-The search can be modified by changing the presence and ordering of elements in \code{search}. 
+The search can be modified by changing the presence and ordering of elements in \code{search}.
 
 If there is a name clash that results in retrieval of an unintended field,
 users should explicitly set \code{by} to a data.frame, DataFrame or AsIs-wrapped vector containing the desired values.
@@ -74,9 +74,9 @@ retrieveCellInfo(example_sce, data.frame(stuff=arbitrary.field))
 \seealso{
 \code{\link{makePerCellDF}}, which provides a more user-friendly interface to this function.
 
-\code{\link{plotColData}}, 
-\code{\link{plotReducedDim}}, 
-\code{\link{plotExpression}}, 
+\code{\link{plotColData}},
+\code{\link{plotReducedDim}},
+\code{\link{plotExpression}},
 \code{\link{plotPlatePosition}},
 and most other cell-based plotting functions.
 }

--- a/man/scater-plot-args.Rd
+++ b/man/scater-plot-args.Rd
@@ -17,8 +17,9 @@ Defaults to 10.}
 Defaults to 0.6.}
 \item{\code{point_size}:}{Numeric scalar, specifying the size of the points.
 Defaults to \code{NULL}.}
-\item{\code{point_shape}:}{Numeric scalar, specifying the size of the points.
-Defaults to \code{19}.}
+\item{\code{point_shape}:}{An integer, or a string specifying the shape
+of the points. Details see \code{vignette("ggplot2-specs")}. Defaults to
+\code{19}.}
 \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}

--- a/man/scater-plot-args.Rd
+++ b/man/scater-plot-args.Rd
@@ -17,6 +17,8 @@ Defaults to 10.}
 Defaults to 0.6.}
 \item{\code{point_size}:}{Numeric scalar, specifying the size of the points.
 Defaults to \code{NULL}.}
+\item{\code{point_shape}:}{Numeric scalar, specifying the size of the points.
+Defaults to \code{19}.}
 \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}


### PR DESCRIPTION
This commit just enable the customization of point shape
The current version (without `point_shape` argument) ofter return a plot with large point:
```
scater::plotReducedDim(
    sce_clean,
    dimred = "UMAP",
    colour_by = "Sample",
    point_size = 0.01,
    point.padding = 0,
    force = 0,
    rasterise = TRUE
) 
```
![image](https://user-images.githubusercontent.com/19575010/204594454-4ae389df-0825-4e13-aedf-59ec56dd0fa3.png)

By adjusting to the `point_shape` argument we can produce a plot with smaller point:
```
scater::plotReducedDim(
    sce_clean,
    dimred = "UMAP",
    colour_by = "Sample",
    point_shape = 16,
    point_size = 0.01,
    point.padding = 0,
    force = 0,
    rasterise = TRUE
)
```
![image](https://user-images.githubusercontent.com/19575010/204594272-4e60b21b-da01-45cc-8dca-23dd2a7d6a56.png)