### PR TITLE
fix wrong group factor levels

### DIFF
--- a/R/plotDots.R
+++ b/R/plotDots.R
@@ -87,7 +87,7 @@ plotDots <- function(object, features, group = NULL, block=NULL,
     if (!is.null(block)) {
         ave <- correctGroupSummary(ave, group=summarized$group, block=summarized$block)
         num <- correctGroupSummary(num, group=summarized$group, block=summarized$block, transform="logit")
-        group.names <- colnames(ave)
+        group.names <- factor(colnames(ave), levels = levels(summarized$group))
     }
     heatmap_scale <- .heatmap_scale(ave, center=center, scale=scale, colour=colour, zlim=zlim)
 


### PR DESCRIPTION
when we provide a "block" argument into `plotDots` function,  we will lose our original group levels
```
scater::plotDots(
        sce_clean, markers,
        block = "Sample",
        group = "label"
) + ggplot2::coord_flip()
```
This is just a snippet figure, but can let us know the problem (the order of the y axis):
![image](https://user-images.githubusercontent.com/19575010/204766759-9ad6ef93-1884-4c4c-a9c4-43a413df17e1.png)

This commit just fix this by providing original levels into the group factor. and same code with the fixed figure is also here:
```
scater::plotDots(
        sce_clean, markers,
        block = "Sample",
        group = "label"
) + ggplot2::coord_flip()
```
![image](https://user-images.githubusercontent.com/19575010/204770666-0b1a20a9-640c-4ecc-8b00-f977de29ec05.png)

