### PR TITLE
Colour mismatch in violin plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Authors@R: c(
         person("Leo", "Lahti", role=c("ctb"), email="leo.lahti@utu.fi",
 	             comment = c(ORCID = "0000-0001-5537-637X"))
 	)
-Version: 1.27.4
-Date: 2022-02-03
+Version: 1.27.5
+Date: 2022-02-07
 License: GPL-3
 Title: Single-Cell Analysis Toolkit for Gene Expression Data in R
 Description: A collection of tools for doing various analyses of

--- a/R/plotExplanatoryPCs.R
+++ b/R/plotExplanatoryPCs.R
@@ -58,7 +58,7 @@ plotExplanatoryPCs <- function(object, nvars_to_plot = 10, npcs_to_plot=50, them
         ylab("% variance explained") +
         coord_cartesian(ylim = c(10 ^ (-3), 100))
 
-    plot_out <- .resolve_plot_colours(plot_out, df_to_plot$Expl_Var, "")
+    plot_out <- .resolve_plot_colours(plot_out, df_to_plot$Expl_Var, "", fill = FALSE, colour = TRUE)
 
     if ( requireNamespace("cowplot", quietly = TRUE) ) {
         plot_out <- plot_out + cowplot::theme_cowplot(theme_size)

--- a/R/plotExplanatoryVariables.R
+++ b/R/plotExplanatoryVariables.R
@@ -56,7 +56,7 @@ plotExplanatoryVariables <- function(object, nvars_to_plot = 10, min_marginal_r2
         ylab("Density") +
         coord_cartesian(xlim = c(10 ^ (-3), 100))
 
-    plot_out <- .resolve_plot_colours(plot_out, df_to_plot$Expl_Var, "")
+    plot_out <- .resolve_plot_colours(plot_out, df_to_plot$Expl_Var, "", colour = TRUE)
 
     if ( requireNamespace("cowplot", quietly = TRUE) ) {
         plot_out <- plot_out + cowplot::theme_cowplot(theme_size)

--- a/R/plotExpression.R
+++ b/R/plotExpression.R
@@ -153,7 +153,7 @@ plotExpression <- function(object, features, x = NULL,
     size_by <- vis_out$size_by
 
     ## Set up the faceting.
-    if ( is.null(evals_long$X) ) { 
+    if (is.null(evals_long$X)) { 
         evals_long$X <- evals_long$Feature
     } else { 
         one_facet <- FALSE 
@@ -169,15 +169,17 @@ plotExpression <- function(object, features, x = NULL,
     } 
 
     # Creating the plot with faceting.        
-    plot_out <- .central_plotter(evals_long, xlab = xlab, ylab = ylab,
-                                 shape_by = shape_by, colour_by = colour_by, size_by = size_by, fill_by = fill_by,
-                                 ..., point_FUN = point_fun)
+    plot_out <- .central_plotter(
+        evals_long, xlab = xlab, ylab = ylab,
+        shape_by = shape_by, colour_by = colour_by, size_by = size_by, fill_by = fill_by,
+        ..., point_FUN = point_fun
+    )
     if (!one_facet) {
         plot_out <- plot_out + facet_wrap(~Feature, ncol = ncol, scales = scales)
     }
         
     # Do not show x-axis ticks or labels if there is no X.
-    if ( is.null(x) ) { 
+    if (is.null(x)) { 
         plot_out <- plot_out + theme(
             axis.text.x = element_text(angle = 60, vjust = 1, hjust = 1),
             axis.ticks.x = element_blank(),

--- a/R/plotHighestExprs.R
+++ b/R/plotHighestExprs.R
@@ -118,7 +118,10 @@ plotHighestExprs <- function(object, n = 50, colour_cells_by = color_cells_by,
               title = element_text(colour = "gray35"))
 
     if (!is.null(colour_cells_by)) {
-        plot_most_expressed <- .resolve_plot_colours(plot_most_expressed, df_exprs_by_cell_long$colour_by, colour_cells_by)
+        plot_most_expressed <- .resolve_plot_colours(
+            plot_most_expressed, df_exprs_by_cell_long$colour_by, colour_cells_by,
+            fill = FALSE, colour = TRUE
+        )
     }
 
     ## Adding median expression values for each gene.

--- a/R/plotPlatePosition.R
+++ b/R/plotPlatePosition.R
@@ -109,7 +109,10 @@ plotPlatePosition <- function(object, plate_position = NULL,
     plot_out <- plot_out + point_out$aes + do.call(geom_point, point_out$args)
 
     if (!is.null(colour_by)) {
-        plot_out <- .resolve_plot_colours(plot_out, df_to_plot$colour_by, colour_by, fill = point_out$fill)
+        plot_out <- .resolve_plot_colours(
+            plot_out, df_to_plot$colour_by, colour_by, fill = point_out$fill,
+            colour = !point_out$fill
+        )
     }
 
     ## Define plotting theme

--- a/R/plotRLE.R
+++ b/R/plotRLE.R
@@ -123,8 +123,9 @@ plotRLE <- function(object, exprs_values="logcounts", exprs_logged = TRUE,
     } 
 
     # Adding colours.
-    plot_out <- .resolve_plot_colours(plot_out, colour_by_vals, colour_by, fill = FALSE)
-    plot_out <- .resolve_plot_colours(plot_out, colour_by_vals, colour_by, fill = TRUE)
+    # plot_out <- .resolve_plot_colours(plot_out, colour_by_vals, colour_by, fill = FALSE)
+    # plot_out <- .resolve_plot_colours(plot_out, colour_by_vals, colour_by, fill = TRUE)
+    plot_out <- .resolve_plot_colours(plot_out, colour_by_vals, colour_by, fill = TRUE, colour = TRUE)
     
     if (!legend) {
         plot_out <- plot_out + theme(legend.position = "none")

--- a/R/plotReducedDim.R
+++ b/R/plotReducedDim.R
@@ -239,7 +239,8 @@ paired_reddim_plot <- function(df_to_plot, to_plot, dimred, percentVar = NULL,
     plot_out <- plot_out + point_out$aes + do.call(geom_point, point_out$args)
     if (!is.null(colour_by)) {
         plot_out <- .resolve_plot_colours(
-            plot_out, df_to_plot$colour_by, colour_by, fill = point_out$fill
+            plot_out, df_to_plot$colour_by, colour_by, fill = point_out$fill,
+            colour = !point_out$fill
         )
     }
 

--- a/R/plotScater.R
+++ b/R/plotScater.R
@@ -104,7 +104,10 @@ plotScater <- function(x, nfeatures = 500, exprs_values = "counts",
 
     ## Add extra plot theme and details
     if ( !is.null(colour_by)) { 
-        plot_out <- .resolve_plot_colours(plot_out, seq_real_estate_long$colour_by, colour_by)
+        plot_out <- .resolve_plot_colours(
+            plot_out, seq_real_estate_long$colour_by, colour_by,
+            fill = FALSE, colour = TRUE
+        )
     }
 
     plot_out <- plot_out + xlab("Number of features") + ylab("Cumulative proportion of library")

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -88,22 +88,36 @@ NULL
             } else {
                 viol_args <- list(mapping=aes(fill=.data[[fill_by]]))
             }
-            plot_out <- plot_out + do.call(geom_violin, c(viol_args, list(colour = "gray60", alpha = 0.2, scale = "width", width = 0.8)))
+            plot_out <- plot_out +
+                do.call(
+                    geom_violin,
+                    c(viol_args, list(colour = "gray60", alpha = 0.2, scale = "width", width = 0.8))
+                )
         }
 
         # Adding median, if requested.
         if (show_median) {
-            plot_out <- plot_out + stat_summary(fun = median, fun.min = median, fun.max = median,
-                                                geom = "crossbar", width = 0.3, alpha = 0.8)
+            plot_out <- plot_out +
+                stat_summary(
+                    fun = median, fun.min = median, fun.max = median,
+                    geom = "crossbar", width = 0.3, alpha = 0.8
+                )
         }
 
         # Adding points.
-        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
+        point_out <- .get_point_args(
+            colour_by, shape_by, size_by,
+            alpha = point_alpha, size = point_size, shape = point_shape
+        )
         if (is.null(point_FUN)) {
             if (jitter_type=="swarm") {
-                point_FUN <- function(...) geom_quasirandom(..., width=0.4, groupOnX=TRUE, bandwidth=1)
+                point_FUN <- function(...) {
+                    geom_quasirandom(..., width=0.4, groupOnX=TRUE, bandwidth=1)
+                }
             } else {
-                point_FUN <- function(...) geom_jitter(..., position = position_jitter(height = 0))
+                point_FUN <- function(...) {
+                    geom_jitter(..., position = position_jitter(height = 0))
+                }
             }
         }
         plot_out <- plot_out + point_out$aes + do.call(point_FUN, point_out$args)
@@ -118,7 +132,10 @@ NULL
         plot_out <- ggplot(object, aes(x=.data$X, y=.data$Y)) + xlab(xlab) + ylab(ylab)
 
         # Adding points.
-        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
+        point_out <- .get_point_args(
+            colour_by, shape_by, size_by,
+            alpha = point_alpha, size = point_size, shape = point_shape
+        )
         if (is.null(point_FUN)) {
             point_FUN <- geom_point
         }
@@ -126,7 +143,8 @@ NULL
 
         # Adding smoothing, if requested.
         if (show_smooth) {
-            plot_out <- plot_out + stat_smooth(colour = "firebrick", linetype = 2, se = show_se)
+            plot_out <- plot_out +
+                stat_smooth(colour = "firebrick", linetype = 2, se = show_se)
         }
 
     } else {
@@ -166,7 +184,10 @@ NULL
                 linewidth = 0.5, fill = 'grey90')
 
         # Adding points.
-        point_out <- .get_point_args(colour_by, shape_by, size_by, alpha = point_alpha, size = point_size, shape = point_shape)
+        point_out <- .get_point_args(
+            colour_by, shape_by, size_by,
+            alpha = point_alpha, size = point_size, shape = point_shape
+        )
         if (is.null(point_FUN)) {
             point_FUN <- geom_point
         }
@@ -175,7 +196,10 @@ NULL
 
     # Adding colour.
     if (!is.null(colour_by)) {
-        plot_out <- .resolve_plot_colours(plot_out, object$colour_by, colour_by, fill = point_out$fill)
+        plot_out <- .resolve_plot_colours(
+            plot_out, object$colour_by, colour_by, fill = point_out$fill,
+            colour = !point_out$fill
+        )
     }
 
     ## Define plotting theme
@@ -199,7 +223,6 @@ NULL
 
 .get_point_args <- function(colour_by, shape_by, size_by, alpha=0.65, size=NULL, shape = NULL) 
 ## Note the use of colour instead of fill when shape_by is set, as not all shapes have fill.
-## (Fill is still the default as it looks nicer.)
 {
     fill_colour <- FALSE
     aes <- list()

--- a/R/plot_colours.R
+++ b/R/plot_colours.R
@@ -36,39 +36,39 @@
 
 #' @importFrom ggplot2 scale_fill_manual scale_colour_manual
 #' @importFrom viridis scale_fill_viridis scale_colour_viridis
-.resolve_plot_colours <- function(plot_out, colour_by, colour_by_name, fill = FALSE) 
+.resolve_plot_colours <- function(plot_out, colour_by, colour_by_name, fill = FALSE, colour = FALSE) 
 # Get nice plotting colour schemes for very general colour variables
 {
-    if ( is.null(colour_by) ) {
+    if (is.null(colour_by)) {
         return(plot_out)
     }
 
     # Picking whether to fill or not.
-    if ( fill ) {
-        VIRIDFUN <- scale_fill_viridis
-        SCALEFUN <- scale_fill_manual
-    } else {
-        VIRIDFUN <- scale_colour_viridis
-        SCALEFUN <- scale_colour_manual
-    }
+    aesthetics <- c("fill", "colour")[c(fill, colour)]
 
+    VIRIDFUN <- scale_colour_viridis
+    SCALEFUN <- scale_colour_manual
+    
     # Set a sensible colour scheme and return the plot_out object
-    if ( is.numeric(colour_by) ) {
-        plot_out <- plot_out + VIRIDFUN(name = colour_by_name)
+    if (is.numeric(colour_by)) {
+        plot_out <- plot_out + VIRIDFUN(name = colour_by_name, aesthetics = aesthetics)
     } else {
         nlevs_colour_by <- nlevels(as.factor(colour_by))
         if (nlevs_colour_by <= 10) {
             plot_out <- plot_out + SCALEFUN(
                 values = .get_palette("tableau10medium"),
-                name = colour_by_name)
+                name = colour_by_name,
+                aesthetics = )
         } else {
             if (nlevs_colour_by > 10 && nlevs_colour_by <= 20) {
                 plot_out <- plot_out + SCALEFUN(
                     values = .get_palette("tableau20"),
-                    name = colour_by_name)
+                    name = colour_by_name,
+                    aesthetics = c("fill", "colour"))
             } else {
                 plot_out <- plot_out + VIRIDFUN(
-                    name = colour_by_name, discrete = TRUE)
+                    name = colour_by_name, discrete = TRUE,
+                    aesthetics = c("fill", "colour"))
             }
         }
     }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,15 @@
 
 \section{Changes in version 1.28.0, Bioconductor 3.17 Release}{
   \itemize{
+    \item Change \code{exprs_values} (and similar) to \code{assay_name}.
+    \item Tweak colouring of violin plots.
+    \item Fix use of block arguments in \code{plotGroupedHeatmap}.
+  }
+}
+
+
+\section{Changes in version 1.28.0, Bioconductor 3.17 Release}{
+  \itemize{
     \item \code{swap_rownames} works in \code{retrieveCellInfo} for
     \code{altExp} now as well as in the main assay.
     \item Add \code{point_shape} argument to \code{plotDots} and


### PR DESCRIPTION
The current violin plot colour/fill is weird. The same colours used for fill and colour scales, but they don't align:

![scater](https://user-images.githubusercontent.com/10779688/217281430-476278b6-6666-4cfa-95b0-12e08f50bdb2.png)

Ideally I'd want something like this instead:

![scater2](https://user-images.githubusercontent.com/10779688/217281894-9d14cbcd-8493-48f1-aa63-2a9ce332cac4.jpg)

Can do this with a simplification of the plotting colour code.