### PR TITLE
Support box plot in addition to violin plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,10 +10,13 @@ Authors@R: c(
         person("Alan", "O'Callaghan", role=c("ctb", "cre"), email="alan.ocallaghan@outlook.com"),
         person("Yun", "Peng", role=c("ctb"), email="yunyunp96@gmail.com"),
         person("Leo", "Lahti", role=c("ctb"), email="leo.lahti@utu.fi",
-	             comment = c(ORCID = "0000-0001-5537-637X"))
+	             comment = c(ORCID = "0000-0001-5537-637X")),
+	    person("Tuomas", "Borman", role = c("ctb"),
+	        email = "tuomas.v.borman@utu.fi",
+            comment = c(ORCID = "0000-0002-8563-8884"))
 	)
-Version: 1.31.2
-Date: 2024-01-28
+Version: 1.31.3
+Date: 2024-06-03
 License: GPL-3
 Title: Single-Cell Analysis Toolkit for Gene Expression Data in R
 Description: A collection of tools for doing various analyses of

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(
             comment = c(ORCID = "0000-0002-8563-8884"))
 	)
 Version: 1.31.3
-Date: 2024-06-03
+Date: 2024-06-04
 License: GPL-3
 Title: Single-Cell Analysis Toolkit for Gene Expression Data in R
 Description: A collection of tools for doing various analyses of

--- a/R/plotExpression.R
+++ b/R/plotExpression.R
@@ -87,6 +87,10 @@
 #' plotExpression(example_sce, rownames(example_sce)[1:6],
 #'     colour_by = "Mutation_Status", shape_by = "Treatment",
 #'     size_by = "Gene_0010")
+#' 
+#' ## use boxplot instead of violin plot
+#' plotExpression(example_sce, rownames(example_sce)[1:6],
+#'     colour_by = "Mutation_Status", show_boxplot = TRUE, show_violin = FALSE)
 #'
 #' ## plot expression against expression values for Gene_0004
 #' plotExpression(example_sce, rownames(example_sce)[1:4],

--- a/R/plotExpression.R
+++ b/R/plotExpression.R
@@ -90,7 +90,7 @@
 #' 
 #' ## use boxplot instead of violin plot
 #' plotExpression(example_sce, rownames(example_sce)[1:6],
-#'     colour_by = "Mutation_Status", show_boxplot = TRUE, show_violin = FALSE)
+#'     show_boxplot = TRUE, show_violin = FALSE)
 #'
 #' ## plot expression against expression values for Gene_0004
 #' plotExpression(example_sce, rownames(example_sce)[1:4],

--- a/R/plotExpression.R
+++ b/R/plotExpression.R
@@ -88,7 +88,7 @@
 #'     colour_by = "Mutation_Status", shape_by = "Treatment",
 #'     size_by = "Gene_0010")
 #' 
-#' ## use boxplot instead of violin plot
+#' ## use boxplot as well as violin plot
 #' plotExpression(example_sce, rownames(example_sce)[1:6],
 #'     show_boxplot = TRUE, show_violin = FALSE)
 #'

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -18,6 +18,7 @@
 #' \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 #' This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 #' The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}
+#' \item{\code{layout}:}{String to define layout of plot. Must be \code{"violin"} (violin plot, default) or \code{"box"} (box plot).}
 #' }
 #'
 #' @section Distributional calculations:
@@ -63,7 +64,7 @@ NULL
 #' @importFrom ggbeeswarm geom_quasirandom
 #' @importFrom ggplot2 ggplot geom_violin xlab ylab stat_summary geom_jitter
 #'   position_jitter coord_flip geom_point stat_smooth geom_tile theme_bw theme
-#'   geom_bin2d geom_hex stat_summary_2d stat_summary_hex
+#'   geom_bin2d geom_hex stat_summary_2d stat_summary_hex geom_boxplot
 .central_plotter <- function(object, xlab = NULL, ylab = NULL,
                              colour_by = NULL, shape_by = NULL, size_by = NULL, fill_by = NULL,
                              show_median = FALSE, show_violin = TRUE, show_smooth = FALSE, show_se = TRUE,
@@ -71,7 +72,7 @@ NULL
                              theme_size = 10, point_alpha = 0.6, point_size = NULL, point_shape = 19, add_legend = TRUE,
                              point_FUN = NULL, jitter_type = "swarm",
                              rasterise = FALSE, scattermore = FALSE, bins = NULL,
-                             summary_fun = "sum", hex = FALSE)
+                             summary_fun = "sum", hex = FALSE, layout = "violin")
 # Internal ggplot-creating function to plot anything that involves points.
 # Creates either a scatter plot, (horizontal) violin plots, or a rectangle plot.
 {
@@ -90,7 +91,7 @@ NULL
         # Adding violins.
         plot_out <- ggplot(object, aes(x=.data$X, y=.data$Y)) +
             xlab(xlab) + ylab(ylab)
-        if (show_violin) {
+        if (show_violin && layout == "violin") {
             if (is.null(fill_by)) {
                 viol_args <- list(fill="grey90")
             } else {
@@ -100,6 +101,18 @@ NULL
                 do.call(
                     geom_violin,
                     c(viol_args, list(colour = "gray60", alpha = 0.2, scale = "width", width = 0.8))
+                )
+        } else if (layout == "box") {
+            # User can choose also to plot box plot instaed of violin plot
+            if (is.null(fill_by)) {
+                box_args <- list(fill="grey90")
+            } else {
+                box_args <- list(mapping=aes(fill=.data[[fill_by]]))
+            }
+            plot_out <- plot_out +
+                do.call(
+                    geom_boxplot,
+                    c(box_args, list(colour = "black", alpha = 0.2))
                 )
         }
 

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -109,11 +109,15 @@ NULL
             } else {
                 box_args <- list(mapping=aes(fill=.data[[fill_by]]))
             }
+            box_args <- c(box_args, list(colour = "black", alpha = 0.2))
+            # If user wants that jitter plot is not added, add outliers.
+            # Otherwise remove outliers since then they would be plotted twice;
+            # once as outlier and once as part of jitter plot.
+            if( !is.na(point_shape) ){
+                box_args[["outlier.shape"]] <- NA
+            }
             plot_out <- plot_out +
-                do.call(
-                    geom_boxplot,
-                    c(box_args, list(colour = "black", alpha = 0.2))
-                )
+                do.call(geom_boxplot, box_args)
         }
 
         # Adding median, if requested.

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -112,14 +112,14 @@ NULL
             }
             # If violin plot is plotted, make the width of box plot smaller to
             # improve readability.
-            if (show_violin){
+            if (show_violin) {
                 box_args[["width"]] <- 0.25
             }
             box_args <- c(box_args, list(colour = "black", alpha = 0.2))
             # If user wants that jitter plot is not added, add outliers.
             # Otherwise remove outliers since then they would be plotted twice;
             # once as outlier and once as part of jitter plot.
-            if( !is.na(point_shape) ){
+            if (!is.na(point_shape)) {
                 box_args[["outlier.shape"]] <- NA
             }
             plot_out <- plot_out +

--- a/R/plot_central.R
+++ b/R/plot_central.R
@@ -18,7 +18,6 @@
 #' \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 #' This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 #' The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}
-#' \item{\code{layout}:}{String to define layout of plot. Must be \code{"violin"} (violin plot, default) or \code{"box"} (box plot).}
 #' }
 #'
 #' @section Distributional calculations:
@@ -31,6 +30,7 @@
 #' Defaults to \code{FALSE}.}
 #' \item{\code{show_se}:}{Logical, should standard errors for the fitted line be shown on a scatter plot when \code{show_smooth=TRUE}?
 #' Defaults to \code{TRUE}.}
+#' \item{\code{show_boxplot}:}{Logical, should a box plot be shown? Defaults to \code{FALSE}.}
 #' }
 #'
 #' @section Miscellaneous fields: Addititional fields can be added to the
@@ -72,7 +72,7 @@ NULL
                              theme_size = 10, point_alpha = 0.6, point_size = NULL, point_shape = 19, add_legend = TRUE,
                              point_FUN = NULL, jitter_type = "swarm",
                              rasterise = FALSE, scattermore = FALSE, bins = NULL,
-                             summary_fun = "sum", hex = FALSE, layout = "violin")
+                             summary_fun = "sum", hex = FALSE, show_boxplot = FALSE)
 # Internal ggplot-creating function to plot anything that involves points.
 # Creates either a scatter plot, (horizontal) violin plots, or a rectangle plot.
 {
@@ -91,7 +91,7 @@ NULL
         # Adding violins.
         plot_out <- ggplot(object, aes(x=.data$X, y=.data$Y)) +
             xlab(xlab) + ylab(ylab)
-        if (show_violin && layout == "violin") {
+        if (show_violin) {
             if (is.null(fill_by)) {
                 viol_args <- list(fill="grey90")
             } else {
@@ -102,12 +102,18 @@ NULL
                     geom_violin,
                     c(viol_args, list(colour = "gray60", alpha = 0.2, scale = "width", width = 0.8))
                 )
-        } else if (layout == "box") {
-            # User can choose also to plot box plot instaed of violin plot
+        }
+        # Adding box plot
+        if (show_boxplot) {
             if (is.null(fill_by)) {
                 box_args <- list(fill="grey90")
             } else {
                 box_args <- list(mapping=aes(fill=.data[[fill_by]]))
+            }
+            # If violin plot is plotted, make the width of box plot smaller to
+            # improve readability.
+            if (show_violin){
+                box_args[["width"]] <- 0.25
             }
             box_args <- c(box_args, list(colour = "black", alpha = 0.2))
             # If user wants that jitter plot is not added, add outliers.

--- a/man/plotExpression.Rd
+++ b/man/plotExpression.Rd
@@ -153,6 +153,10 @@ plotExpression(example_sce, rownames(example_sce)[1:6],
     colour_by = "Mutation_Status", shape_by = "Treatment",
     size_by = "Gene_0010")
 
+## use boxplot instead of violin plot
+plotExpression(example_sce, rownames(example_sce)[1:6],
+    colour_by = "Mutation_Status", show_boxplot = TRUE, show_violin = FALSE)
+
 ## plot expression against expression values for Gene_0004
 plotExpression(example_sce, rownames(example_sce)[1:4],
     "Gene_0004", show_smooth = TRUE)

--- a/man/plotExpression.Rd
+++ b/man/plotExpression.Rd
@@ -155,7 +155,7 @@ plotExpression(example_sce, rownames(example_sce)[1:6],
 
 ## use boxplot instead of violin plot
 plotExpression(example_sce, rownames(example_sce)[1:6],
-    colour_by = "Mutation_Status", show_boxplot = TRUE, show_violin = FALSE)
+    show_boxplot = TRUE, show_violin = FALSE)
 
 ## plot expression against expression values for Gene_0004
 plotExpression(example_sce, rownames(example_sce)[1:4],

--- a/man/scater-plot-args.Rd
+++ b/man/scater-plot-args.Rd
@@ -23,7 +23,6 @@ of the points. Details see \code{vignette("ggplot2-specs")}. Defaults to
 \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}
-\item{\code{layout}:}{String to define layout of plot. Must be \code{"violin"} (violin plot, default) or \code{"box"} (box plot).}
 }
 }
 
@@ -38,6 +37,7 @@ Defaults to \code{TRUE}.}
 Defaults to \code{FALSE}.}
 \item{\code{show_se}:}{Logical, should standard errors for the fitted line be shown on a scatter plot when \code{show_smooth=TRUE}?
 Defaults to \code{TRUE}.}
+\item{\code{show_boxplot}:}{Logical, should a box plot be shown? Defaults to \code{FALSE}.}
 }
 }
 

--- a/man/scater-plot-args.Rd
+++ b/man/scater-plot-args.Rd
@@ -23,6 +23,7 @@ of the points. Details see \code{vignette("ggplot2-specs")}. Defaults to
 \item{\code{jitter_type}:}{String to define how points are to be jittered in a violin plot.
 This is either with random jitter on the x-axis (\code{"jitter"}) or in a \dQuote{beeswarm} style (if \code{"swarm"}, default).
 The latter usually looks more attractive, but for datasets with a large number of cells, or for dense plots, the jitter option may work better.}
+\item{\code{layout}:}{String to define layout of plot. Must be \code{"violin"} (violin plot, default) or \code{"box"} (box plot).}
 }
 }
 


### PR DESCRIPTION
Related to this issue: https://github.com/alanocallaghan/scater/issues/207

This PR adds support for box plot. In addition to violin plot, user can also choose to visualize the data with box plot, This can be done by specifying `layout = "box`. I tried to follow your coding style, and this should be minimum modifications to get the support.

Here are examples on functionality

```
example_sce <- mockSCE()
example_sce <- logNormCounts(example_sce)

#
colData(example_sce) <- cbind(colData(example_sce), perCellQCMetrics(example_sce))

plots <- list()
plots[[1]] <- plotColData(example_sce, y = "Treatment", x = "sum", colour_by = "Mutation_Status", layout = "box")
plots[[2]] <- plotColData(example_sce, y = "Treatment", x = "sum", colour_by = "Mutation_Status")
plots[[3]] <- plotColData(example_sce, y = "detected", x = "Cell_Cycle", colour_by = "Mutation_Status", layout = "test")
plots[[4]] <- plotColData(example_sce, y = "detected", x = "Cell_Cycle", colour_by = "Mutation_Status", layout = "violin")
#
plots[[5]] <- plotExpression(example_sce, rownames(example_sce)[1:5])
plots[[6]] <- plotExpression(example_sce, c("Gene_0001", "Gene_0004"), x="Mutation_Status", layout = "violin")
plots[[7]] <- plotExpression(example_sce, rownames(example_sce)[1:5], layout = "box", point_alpha = 0.1, show_se = TRUE)
plots[[8]] <- plotExpression(example_sce, c("Gene_0001", "Gene_0004"), x="Mutation_Status", layout = "box", show_smooth = TRUE)
#
rowData(example_sce) <- cbind(rowData(example_sce), perFeatureQCMetrics(example_sce))

plots[[9]] <- plotRowData(example_sce, y="mean", show_median = TRUE)
plots[[10]] <- plotRowData(example_sce, y="mean", layout = "box", show_violin = TRUE)

library(patchwork)

wrap_plots(plots)
```
![image](https://github.com/alanocallaghan/scater/assets/60338854/10bc894a-7612-46b9-b715-c9947294b27f)



-Tuomas

