### PR TITLE
Remove default seed from runNMF

### DIFF
--- a/R/runNMF.R
+++ b/R/runNMF.R
@@ -8,9 +8,8 @@
 #' For \code{runNMF}, a \linkS4class{SingleCellExperiment} object.
 #' @param ncomponents Numeric scalar indicating the number of NMF dimensions to obtain.
 #' @inheritParams runPCA
-#' @param seed Random number generation seed to be passed to \code{\link[RcppML]{nmf}}.
 #' @param ... For the \code{calculateNMF} generic, additional arguments to pass to specific methods.
-#' For the ANY method, additional arguments to pass to \code{\link[Rtsne]{Rtsne}}.
+#' For the ANY method, additional arguments to pass to \code{\link[RcppML]{nmf}}.
 #' For the SummarizedExperiment and SingleCellExperiment methods, additional arguments to pass to the ANY method.
 #'
 #' For \code{runNMF}, additional arguments to pass to \code{calculateNMF}.
@@ -51,14 +50,14 @@ NULL
 #' @importFrom BiocNeighbors KmknnParam findKNN
 #' @importFrom BiocParallel SerialParam
 .calculate_nmf <- function(x, ncomponents = 2, ntop = 500,
-    subset_row = NULL, scale=FALSE, transposed=FALSE, seed=1, ...)
+    subset_row = NULL, scale=FALSE, transposed=FALSE, ...)
 { 
     if (!transposed) {
         x <- .get_mat_for_reddim(x, subset_row=subset_row, ntop=ntop, scale=scale) 
     }
     x <- t(as.matrix(x))
 
-    args <- list(k=ncomponents, verbose=FALSE, seed=seed, ...)
+    args <- list(k=ncomponents, verbose=FALSE, ...)
     nmf_out <- do.call(RcppML::nmf, c(list(x), args))
 
     # RcppML doesn't use transposed data

--- a/man/runNMF.Rd
+++ b/man/runNMF.Rd
@@ -17,7 +17,6 @@ calculateNMF(x, ...)
   subset_row = NULL,
   scale = FALSE,
   transposed = FALSE,
-  seed = 1,
   ...
 )
 
@@ -41,7 +40,7 @@ Alternatively, a \linkS4class{SummarizedExperiment} or \linkS4class{SingleCellEx
 For \code{runNMF}, a \linkS4class{SingleCellExperiment} object.}
 
 \item{...}{For the \code{calculateNMF} generic, additional arguments to pass to specific methods.
-For the ANY method, additional arguments to pass to \code{\link[Rtsne]{Rtsne}}.
+For the ANY method, additional arguments to pass to \code{\link[RcppML]{nmf}}.
 For the SummarizedExperiment and SingleCellExperiment methods, additional arguments to pass to the ANY method.
 
 For \code{runNMF}, additional arguments to pass to \code{calculateNMF}.}
@@ -56,8 +55,6 @@ This can be a character vector of row names, an integer vector of row indices or
 \item{scale}{Logical scalar, should the expression values be standardized?}
 
 \item{transposed}{Logical scalar, is \code{x} transposed with cells in rows?}
-
-\item{seed}{Random number generation seed to be passed to \code{\link[RcppML]{nmf}}.}
 
 \item{exprs_values}{Alias to \code{assay.type}.}
 


### PR DESCRIPTION
When working with the `calculateNMF()` function (with the release version of `scater`), I realized that the default arguments result in resetting the system seed, which seems like undesired behavior, both because it means that repeated runs do not vary as would be expected (and as the docs seem to indicate).

For example:
``` r
sce <- mockSCE() |> logNormCounts()

set.seed(100)
nmf1 <- calculateNMF(sce)
runif(1)
#> [1] 0.5308088
nmf2 <- calculateNMF(sce)
runif(1)
#> [1] 0.5308088
all(nmf1==nmf2)
#> [1] TRUE
```

Setting the default seed as `NULL` seems to correctly alleviate the issue (and this is the default `seed` value for the underlying `RccpML::nmf()`): 

``` r
set.seed(100)
nmf1 <- calculateNMF(sce, seed = NULL)
runif(1)
#> [1] 0.0740483

# second run is different and not in the same RNG position
nmf2 <- calculateNMF(sce, seed = NULL)
runif(1)
#> [1] 0.7676133
all(nmf1==nmf2)
#> [1] FALSE

# resetting the seed does result in identical values, as expected
set.seed(100)
nmf3 <- calculateNMF(sce, seed = NULL)
runif(1)
#> [1] 0.0740483
all(nmf1==nmf3)
#> [1] TRUE
```

<sup>Created on 2025-02-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Since the pattern from other similar functions like `calculateUMAP()` is to not include `seed` as a default argument, the simplest solution seemed to me to be to simply remove the argument, allowing the default value for `RcppML::nmf()` to be used. That is what I have done here.

I also fixed a small error in the docs which referred to passing additional arguments to `Rtsne`.

If you would like to pursue a different solution (or leave it as is), please let me know.


