### PR TITLE
Make identities of summarized columns are more obviously correct.

### DIFF
--- a/R/plotDots.R
+++ b/R/plotDots.R
@@ -81,11 +81,13 @@ plotDots <- function(object, features, group = NULL, block=NULL,
     }
 
     combo.ids <- S4Vectors::selfmatch(ids)
-    submat <- assay(object, assay.type)[as.character(features), , drop = FALSE]
-    ave <- quick_means_by_group(submat, combo.ids)
-    num <- quick_means_by_group(submat > detection_limit, combo.ids)
-    summarized <- ids[!duplicated(combo.ids),,drop=FALSE]
+    is.unique.id <- !duplicated(combo.ids)
+    summarized <- ids[is.unique.id,,drop=FALSE]
     group.names <- summarized$group
+    submat <- assay(object, assay.type)[as.character(features), , drop = FALSE]
+    m <- match(combo.ids, combo.ids[is.unique.id])
+    ave <- quick_means_by_group(submat, nrow(summarized), m)
+    num <- quick_means_by_group(submat > detection_limit, nrow(summarized), m)
 
     if (!is.null(block)) {
         ave <- correctGroupSummary(ave, group=summarized$group, block=summarized$block)

--- a/R/plotGroupedHeatmap.R
+++ b/R/plotGroupedHeatmap.R
@@ -83,8 +83,10 @@ plotGroupedHeatmap <- function(object, features, group, block = NULL,
     }
 
     combo.ids <- S4Vectors::selfmatch(ids)
-    heat.mat <- quick_means_by_group(heat.vals, combo.ids)
-    heat.ids <- ids[!duplicated(combo.ids),]
+    is.unique.id <- !duplicated(combo.ids)
+    heat.ids <- ids[is.unique.id,,drop=FALSE]
+    heat.mat <- quick_means_by_group(heat.vals, nrow(heat.ids), match(combo.ids, combo.ids[is.unique.id]))
+    colnames(heat.mat) <- heat.ids$group
 
     if (!is.null(block)) {
         heat.mat <- correctGroupSummary(heat.mat, group=heat.ids$group, block=heat.ids$block)

--- a/R/reexports.R
+++ b/R/reexports.R
@@ -80,14 +80,9 @@ scuttle::sumCountsAcrossFeatures
 scuttle::uniquifyFeatureNames
 
 # Vendored from scuttle given that it's otherwise deprecated and we don't want to add a dependency on scrapper.
-quick_means_by_group <- function(x, groups) {
-    groups <- factor(groups)
-    num.groups <- nlevels(groups)
-    gid <- as.integer(groups)
-
-    multiplier <- Matrix::sparseMatrix(i = seq_along(gid), j = gid, x = rep(1, length(groups)))
+quick_means_by_group <- function(x, num.groups, group.id) {
+    multiplier <- Matrix::sparseMatrix(i = seq_along(group.id), j = group.id, x = rep(1, length(group.id)))
     sums <- x %*% multiplier
-    group.sizes <- tabulate(gid, nbins=num.groups)
-
+    group.sizes <- tabulate(group.id, nbins=num.groups)
     t(t(as.matrix(sums)) / group.sizes)
 }


### PR DESCRIPTION
It was actually correct already but the correctness was hard to prove; now it should be obvious that the columns of the summarized matrix match up to the rows of the dataframe containing the group + block identities.